### PR TITLE
Fix Trix JS Errors When Disabling File Uploads and Clearing Rows

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -261,7 +261,7 @@ var profiles = function ($, undefined) {
    * @param {HTMLElement} elem
    */
   var clear_row = function clear_row(elem) {
-    parent_elem = $(elem).parent().parent();
+    var parent_elem = $(elem).parent().parent();
     parent_elem.slideUp().find("input[type=text], input[type=url], input[type=month], input.clearable, textarea, select").val('');
     var list_container = parent_elem[0].parentElement;
     if (elem.dataset.remove === 'true') {
@@ -705,8 +705,9 @@ $(function () {
 // Trix editor settings
 if ((typeof Trix === "undefined" ? "undefined" : _typeof(Trix)) === 'object') {
   document.addEventListener('trix-initialize', function (e) {
-    document.querySelector('trix-toolbar .trix-button-group--history-tools').remove();
-    document.querySelector('trix-toolbar .trix-button-group--file-tools').remove();
+    var _document$querySelect2, _document$querySelect3;
+    (_document$querySelect2 = document.querySelector('trix-toolbar .trix-button-group--history-tools')) === null || _document$querySelect2 === void 0 || _document$querySelect2.remove();
+    (_document$querySelect3 = document.querySelector('trix-toolbar .trix-button-group--file-tools')) === null || _document$querySelect3 === void 0 || _document$querySelect3.remove();
   });
   document.addEventListener('trix-file-accept', function (e) {
     e.preventDefault();

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,6 +1,6 @@
 {
-    "/js/app.js": "/js/app.js?id=bb647bfe8f8b8ae096323cb6ea42da03",
-    "/js/app.js.map": "/js/app.js.map?id=9f321a4814e4648916c37b2e980f55e7",
+    "/js/app.js": "/js/app.js?id=c447fe9c89c804aa1147b0351d0009a2",
+    "/js/app.js.map": "/js/app.js.map?id=55201ca1444675c47714f464498b2dd5",
     "/js/manifest.js": "/js/manifest.js?id=dc9ead3d7857b522d7de22d75063453c",
     "/js/manifest.js.map": "/js/manifest.js.map?id=389e00e7d7680b68d4e1d128ce27ff48",
     "/css/app.css": "/css/app.css?id=bc1752c1cc35e38e55b5e618b7b4f544",

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -648,8 +648,11 @@ $(function() {
 // Trix editor settings
 if (typeof Trix === 'object') {
     document.addEventListener('trix-initialize', (e) => {
-        document.querySelector('trix-toolbar .trix-button-group--history-tools').remove();
-        document.querySelector('trix-toolbar .trix-button-group--file-tools').remove();
+        const history_tools = document.querySelector('trix-toolbar .trix-button-group--history-tools');
+        const file_tools = document.querySelector('trix-toolbar .trix-button-group--file-tools');
+        
+        if (history_tools) history_tools.remove();
+        if (file_tools) file_tools.remove();
     });
     document.addEventListener('trix-file-accept', (e) => {
         e.preventDefault();

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -210,7 +210,7 @@ var profiles = (function ($, undefined) {
      * @param {HTMLElement} elem
      */
     var clear_row = function (elem) {
-        parent_elem = $(elem).parent().parent();
+        const parent_elem = $(elem).parent().parent();
         parent_elem.slideUp().find("input[type=text], input[type=url], input[type=month], input.clearable, textarea, select").val('');
 
         const list_container = parent_elem[0].parentElement;

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -648,11 +648,8 @@ $(function() {
 // Trix editor settings
 if (typeof Trix === 'object') {
     document.addEventListener('trix-initialize', (e) => {
-        const history_tools = document.querySelector('trix-toolbar .trix-button-group--history-tools');
-        const file_tools = document.querySelector('trix-toolbar .trix-button-group--file-tools');
-        
-        if (history_tools) history_tools.remove();
-        if (file_tools) file_tools.remove();
+        document.querySelector('trix-toolbar .trix-button-group--history-tools')?.remove();
+        document.querySelector('trix-toolbar .trix-button-group--file-tools')?.remove();
     });
     document.addEventListener('trix-file-accept', (e) => {
         e.preventDefault();


### PR DESCRIPTION
1. **Fix ReferenceError in the `clear_row()` function**. 
- In Firefox, the error message shows as: Uncaught ReferenceError: assignment to undeclared variable parent_elem.
- **Steps to reproduce:** on any profile page that has manual edit publications, click on the "Edit" button of the publications section and **click on the "x" button in the top right corner of any publication row to remove it**. 

2. **Fix selector errors when disabling Trix file uploads.**
- In Firefox, the error message shows as: Uncaught TypeError: can't access property "remove", document.querySelector(...) is null.
- **Steps to reproduce:** on any profile page that has manual edit publications, click on the "Edit" button of the publications section and **click on the "Insert New Item" button located in either the top or bottom section of the page**. 