### PR TITLE
Fix Logic to Refresh Students Property

### DIFF
--- a/app/Http/Livewire/ProfileStudents.php
+++ b/app/Http/Livewire/ProfileStudents.php
@@ -77,13 +77,12 @@ class ProfileStudents extends Component
 
     public function updated($name, $value)
     {
-        $this->refreshStudents();
         $this->emitFilterUpdatedEvent($name, $value);
     }
 
     public function refreshStudents()
     {
-        $this->students = $this->getStudentsProperty();
+        unset($this->students);
     }
 
     public function render()


### PR DESCRIPTION
After filing a student application and applying a filter, the students are not categorized correctly. See issue #154 for steps to reproduce.

Refreshing the students after updating the component fixes the issue (done in PR #179). However, after adding a new property to the component in PR #200, and updating it via wire directive triggers the update() lifecycle hook, resulting in a `refreshStudents()` call, which represents an unnecessary and slow request.

After investigating the original bug further, it was found that when the $students property is set to a static value in the refreshStudents() method, it is treated as a public property and no longer works as a computed property. When the component is re-hydrated, the application pivot relationship is not loaded.

See issues [livewire/livewire#3487](https://github.com/livewire/livewire/discussions/3487) and [livewire/livewire#1272 (comment)](https://github.com/livewire/livewire/issues/1272#issuecomment-709602010) Related to why public properties that are model instances are not serialized with the entire model (or pivot relationship) during the re-hydration process. 
[Livewire hydration documentation](https://livewire.laravel.com/docs/3.x/hydration).

The proper fix is to reset the $students property using unset() in order to preserve the computed property behavior.