### PR TITLE
Profile Page Accessibility Fixes

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -9618,6 +9618,11 @@ h3, h4, h5, h6 {
   color: rgb(174.87, 70.47, 0);
 }
 
+ul.list-unstyled {
+  padding-inline-start: 0;
+  list-style-type: none;
+}
+
 img {
   max-width: 100%;
   height: auto;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -10674,19 +10674,21 @@ button.video-control .fa-play {
 .profile .contact_info > div {
   margin-top: 30px;
 }
-.profile h3 {
+.profile h2 {
   font-weight: lighter;
   font-size: 1.8rem;
   margin-bottom: 1.4rem;
   z-index: 0;
   position: relative;
+  margin-top: 1rem;
 }
-.profile h5 {
+.profile h3 {
   clear: both;
   margin-bottom: 15px;
 }
-.profile h6 {
+.profile h4 {
   color: #c95100;
+  font-size: 1rem;
 }
 .profile .links {
   text-align: center;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -9618,6 +9618,16 @@ h3, h4, h5, h6 {
   color: rgb(174.87, 70.47, 0);
 }
 
+.has-external-link-icon {
+  text-decoration: none;
+}
+.has-external-link-icon:hover {
+  text-decoration: none;
+}
+.has-external-link-icon span {
+  text-decoration: underline;
+}
+
 ul.list-unstyled {
   padding-inline-start: 0;
   list-style-type: none;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -9628,11 +9628,6 @@ h3, h4, h5, h6 {
   text-decoration: underline;
 }
 
-ul.list-unstyled {
-  padding-inline-start: 0;
-  list-style-type: none;
-}
-
 img {
   max-width: 100%;
   height: auto;

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -3,8 +3,8 @@
     "/js/app.js.map": "/js/app.js.map?id=271c8f103c569b8f5613b8778d48ee75",
     "/js/manifest.js": "/js/manifest.js?id=dc9ead3d7857b522d7de22d75063453c",
     "/js/manifest.js.map": "/js/manifest.js.map?id=389e00e7d7680b68d4e1d128ce27ff48",
-    "/css/app.css": "/css/app.css?id=2e53ab5f99f2a92ca938e302dd303ff8",
-    "/css/app.css.map": "/css/app.css.map?id=614b55427340fe572f67e9cb3f1cf76f",
+    "/css/app.css": "/css/app.css?id=134d47945758d2b1c346de45f027d267",
+    "/css/app.css.map": "/css/app.css.map?id=3505676b3c363f41254329a533224bef",
     "/js/vendor.js": "/js/vendor.js?id=77012e19e850a379f73e3ac0c76bc9b1",
     "/js/vendor.js.map": "/js/vendor.js.map?id=f3f5514d1186aa088c887b6ebe999fe0"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -3,8 +3,8 @@
     "/js/app.js.map": "/js/app.js.map?id=271c8f103c569b8f5613b8778d48ee75",
     "/js/manifest.js": "/js/manifest.js?id=dc9ead3d7857b522d7de22d75063453c",
     "/js/manifest.js.map": "/js/manifest.js.map?id=389e00e7d7680b68d4e1d128ce27ff48",
-    "/css/app.css": "/css/app.css?id=f90016049bdab1b4c970813a96c5dc16",
-    "/css/app.css.map": "/css/app.css.map?id=2d814da1c448178c80ec0bd6fc4884ca",
+    "/css/app.css": "/css/app.css?id=2e53ab5f99f2a92ca938e302dd303ff8",
+    "/css/app.css.map": "/css/app.css.map?id=614b55427340fe572f67e9cb3f1cf76f",
     "/js/vendor.js": "/js/vendor.js?id=77012e19e850a379f73e3ac0c76bc9b1",
     "/js/vendor.js.map": "/js/vendor.js.map?id=f3f5514d1186aa088c887b6ebe999fe0"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -3,8 +3,8 @@
     "/js/app.js.map": "/js/app.js.map?id=271c8f103c569b8f5613b8778d48ee75",
     "/js/manifest.js": "/js/manifest.js?id=dc9ead3d7857b522d7de22d75063453c",
     "/js/manifest.js.map": "/js/manifest.js.map?id=389e00e7d7680b68d4e1d128ce27ff48",
-    "/css/app.css": "/css/app.css?id=0fd161f323dd5c77642c3240bbb47d16",
-    "/css/app.css.map": "/css/app.css.map?id=3ba6add83b449d9a830b1160dc25d43d",
+    "/css/app.css": "/css/app.css?id=9607b1ccff2cb29c46c056705112da70",
+    "/css/app.css.map": "/css/app.css.map?id=69acc964b0737c2466ff06351d745ace",
     "/js/vendor.js": "/js/vendor.js?id=77012e19e850a379f73e3ac0c76bc9b1",
     "/js/vendor.js.map": "/js/vendor.js.map?id=f3f5514d1186aa088c887b6ebe999fe0"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -3,8 +3,8 @@
     "/js/app.js.map": "/js/app.js.map?id=271c8f103c569b8f5613b8778d48ee75",
     "/js/manifest.js": "/js/manifest.js?id=dc9ead3d7857b522d7de22d75063453c",
     "/js/manifest.js.map": "/js/manifest.js.map?id=389e00e7d7680b68d4e1d128ce27ff48",
-    "/css/app.css": "/css/app.css?id=9607b1ccff2cb29c46c056705112da70",
-    "/css/app.css.map": "/css/app.css.map?id=69acc964b0737c2466ff06351d745ace",
+    "/css/app.css": "/css/app.css?id=f90016049bdab1b4c970813a96c5dc16",
+    "/css/app.css.map": "/css/app.css.map?id=2d814da1c448178c80ec0bd6fc4884ca",
     "/js/vendor.js": "/js/vendor.js?id=77012e19e850a379f73e3ac0c76bc9b1",
     "/js/vendor.js.map": "/js/vendor.js.map?id=f3f5514d1186aa088c887b6ebe999fe0"
 }

--- a/resources/assets/sass/_core.scss
+++ b/resources/assets/sass/_core.scss
@@ -18,6 +18,11 @@ a {
 	}
 }
 
+ul.list-unstyled {
+    padding-inline-start: 0;
+    list-style-type: none;
+}
+
 img{
 	max-width: 100%;
 	height: auto;

--- a/resources/assets/sass/_core.scss
+++ b/resources/assets/sass/_core.scss
@@ -18,6 +18,18 @@ a {
 	}
 }
 
+.has-external-link-icon {
+    text-decoration: none;
+
+    &:hover {
+        text-decoration: none;
+    }
+
+    span {
+        text-decoration: underline;
+    }
+}
+
 ul.list-unstyled {
     padding-inline-start: 0;
     list-style-type: none;

--- a/resources/assets/sass/_core.scss
+++ b/resources/assets/sass/_core.scss
@@ -30,11 +30,6 @@ a {
     }
 }
 
-ul.list-unstyled {
-    padding-inline-start: 0;
-    list-style-type: none;
-}
-
 img{
 	max-width: 100%;
 	height: auto;

--- a/resources/assets/sass/_profile.scss
+++ b/resources/assets/sass/_profile.scss
@@ -105,21 +105,23 @@
 		}
     }
 
-	h3 {
+	h2 {
 		font-weight: lighter;
 		font-size: 1.8rem;
 		margin-bottom: 1.4rem;
 		z-index: 0;
 		position: relative;
+		margin-top: 1rem;
     }
 
-	h5 {
+	h3 {
 		clear: both;
 		margin-bottom: 15px;
     }
 
-	h6 {
+	h4 {
 		color: $utd-web-orange;
+		font-size: 1rem;
 	}
 	
 	.links {

--- a/resources/views/livewire/profile-data-cards/activities.blade.php
+++ b/resources/views/livewire/profile-data-cards/activities.blade.php
@@ -1,8 +1,8 @@
 <section id="activities" class="card">
-    <h3><i class="fas fa-chart-line" aria-hidden="true"></i> Activities @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'activities']) }}" aria-label="Edit Publications"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+    <h2><i class="fas fa-chart-line" aria-hidden="true"></i> Activities @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'activities']) }}" aria-label="Edit Publications"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     @foreach($data as $activity)
         <div class="entry">
-            <h5>{{$activity->title}}</h5>
+            <h3>{{$activity->title}}</h3>
             {!! Purify::clean($activity->description) !!}
             @if($activity->start_date)[{{$activity->start_date}}&ndash;{{$activity->end_date}}] @endif
         </div>

--- a/resources/views/livewire/profile-data-cards/activities.blade.php
+++ b/resources/views/livewire/profile-data-cards/activities.blade.php
@@ -1,4 +1,4 @@
-<section id="activities" role="region" class="card" aria-labelledby="activities-heading">
+<section id="activities" class="card" aria-labelledby="activities-heading">
     <h2 id="activities-heading"><i class="fas fa-chart-line" aria-hidden="true"></i> Activities @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'activities']) }}" aria-label="Edit Publications"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $activity)

--- a/resources/views/livewire/profile-data-cards/activities.blade.php
+++ b/resources/views/livewire/profile-data-cards/activities.blade.php
@@ -1,13 +1,13 @@
-<section id="activities" class="card">
-    <h2><i class="fas fa-chart-line" aria-hidden="true"></i> Activities @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'activities']) }}" aria-label="Edit Publications"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
+<section id="activities" role="region" class="card" aria-labelledby="activities-heading">
+    <h2 id="activities-heading"><i class="fas fa-chart-line" aria-hidden="true"></i> Activities @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'activities']) }}" aria-label="Edit Publications"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $activity)
-            <li>
+            <li aria-label="{{$activity->title}}">
                 <article>
                     @if($activity->title)
                         <h3>{{$activity->title}}</h3>
                     @endif
-                    {!! Purify::clean($activity->description) !!}
+                    <p>{!! Purify::clean($activity->description) !!}</p>
                     @if($activity->start_date)[{{$activity->start_date}}&ndash;{{$activity->end_date}}] @endif
                 </article>
             </li>

--- a/resources/views/livewire/profile-data-cards/activities.blade.php
+++ b/resources/views/livewire/profile-data-cards/activities.blade.php
@@ -2,7 +2,7 @@
     <h2 id="activities-heading"><i class="fas fa-chart-line" aria-hidden="true"></i> Activities @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'activities']) }}" aria-label="Edit Publications"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $activity)
-            <li aria-label="{{$activity->title}}">
+            <li>
                 <article>
                     @if($activity->title)
                         <h3>{{$activity->title}}</h3>

--- a/resources/views/livewire/profile-data-cards/activities.blade.php
+++ b/resources/views/livewire/profile-data-cards/activities.blade.php
@@ -1,12 +1,18 @@
 <section id="activities" class="card">
     <h2><i class="fas fa-chart-line" aria-hidden="true"></i> Activities @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'activities']) }}" aria-label="Edit Publications"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
-    @foreach($data as $activity)
-        <div class="entry">
-            <h3>{{$activity->title}}</h3>
-            {!! Purify::clean($activity->description) !!}
-            @if($activity->start_date)[{{$activity->start_date}}&ndash;{{$activity->end_date}}] @endif
-        </div>
-    @endforeach
+    <ul class="list-unstyled">
+        @foreach($data as $activity)
+            <li>
+                <article>
+                    @if($activity->title)
+                        <h3>{{$activity->title}}</h3>
+                    @endif
+                    {!! Purify::clean($activity->description) !!}
+                    @if($activity->start_date)[{{$activity->start_date}}&ndash;{{$activity->end_date}}] @endif
+                </article>
+            </li>
+        @endforeach
+    </ul>
     @if($paginated)
         {{ $data->links() }}
     @endif

--- a/resources/views/livewire/profile-data-cards/additionals.blade.php
+++ b/resources/views/livewire/profile-data-cards/additionals.blade.php
@@ -1,11 +1,12 @@
 <section id="additionals" class="card">
     <h2><i class="fas fa-sticky-note" aria-hidden="true"></i> Additional Information @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'additionals']) }}" aria-label="Edit Additional Information"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
-    @foreach($data as $additional)
-        <div class="entry">
-            <h3><i class="far fa-sticky-note" aria-hidden="true"></i> {{$additional->title}}</h3>
-                {!! Purify::clean($additional->description) !!}
-        </div>
-    @endforeach
+    <ul class="list-unstyled">
+        @foreach($data as $additional)
+            <li class="entry">
+                <h3><i class="far fa-sticky-note" aria-hidden="true"></i> {{$additional->title}}</h3>
+            </li>
+        @endforeach
+    </ul>
     @if($paginated)
         {{ $data->links() }}
     @endif

--- a/resources/views/livewire/profile-data-cards/additionals.blade.php
+++ b/resources/views/livewire/profile-data-cards/additionals.blade.php
@@ -3,7 +3,19 @@
     <ul class="list-unstyled">
         @foreach($data as $additional)
             <li class="entry">
-                <h3><i class="far fa-sticky-note" aria-hidden="true"></i> {{$additional->title}}</h3>
+                @if($additional->url)
+                    <h3>
+                        <a target="_blank" href="{{$additional->url}}" class="has-external-link-icon">
+                            <i class="far fa-sticky-note" aria-hidden="true"></i>
+                            <span class="has-external-link-icon">{!! Purify::clean($additional->title) !!}</span>
+                            <i class="fas fa-external-link-alt"></i>
+                            <span class="sr-only"> (opens in a new tab)</span>
+                        </a>
+                    </h3>
+                @else
+                    <h3><i class="far fa-sticky-note" aria-hidden="true"></i> {{$additional->title}}</h3>
+                @endif
+                {!! Purify::clean($additional->description) !!}
             </li>
         @endforeach
     </ul>

--- a/resources/views/livewire/profile-data-cards/additionals.blade.php
+++ b/resources/views/livewire/profile-data-cards/additionals.blade.php
@@ -1,4 +1,4 @@
-<section id="additionals" role="region" class="card" aria-labelledby="additionals-heading">
+<section id="additionals" class="card" aria-labelledby="additionals-heading">
     <h2 id="additionals-heading"><i class="fas fa-sticky-note" aria-hidden="true"></i> Additional Information @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'additionals']) }}" aria-label="Edit Additional Information"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $additional)

--- a/resources/views/livewire/profile-data-cards/additionals.blade.php
+++ b/resources/views/livewire/profile-data-cards/additionals.blade.php
@@ -1,8 +1,8 @@
-<section id="additionals" class="card">
-    <h2><i class="fas fa-sticky-note" aria-hidden="true"></i> Additional Information @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'additionals']) }}" aria-label="Edit Additional Information"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
+<section id="additionals" role="region" class="card" aria-labelledby="additionals-heading">
+    <h2 id="additionals-heading"><i class="fas fa-sticky-note" aria-hidden="true"></i> Additional Information @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'additionals']) }}" aria-label="Edit Additional Information"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $additional)
-            <li class="entry">
+            <li class="entry" aria-label="{{$additional->title}}">
                 @if($additional->url)
                     <h3>
                         <a target="_blank" href="{{$additional->url}}" class="has-external-link-icon">
@@ -15,7 +15,7 @@
                 @else
                     <h3><i class="far fa-sticky-note" aria-hidden="true"></i> {{$additional->title}}</h3>
                 @endif
-                {!! Purify::clean($additional->description) !!}
+                <p>{!! Purify::clean($additional->description) !!}</p>
             </li>
         @endforeach
     </ul>

--- a/resources/views/livewire/profile-data-cards/additionals.blade.php
+++ b/resources/views/livewire/profile-data-cards/additionals.blade.php
@@ -2,7 +2,7 @@
     <h2 id="additionals-heading"><i class="fas fa-sticky-note" aria-hidden="true"></i> Additional Information @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'additionals']) }}" aria-label="Edit Additional Information"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $additional)
-            <li class="entry" aria-label="{{$additional->title}}">
+            <li class="entry">
                 @if($additional->url)
                     <h3>
                         <a target="_blank" href="{{$additional->url}}" class="has-external-link-icon">

--- a/resources/views/livewire/profile-data-cards/additionals.blade.php
+++ b/resources/views/livewire/profile-data-cards/additionals.blade.php
@@ -1,8 +1,8 @@
 <section id="additionals" class="card">
-    <h3><i class="fas fa-sticky-note" aria-hidden="true"></i> Additional Information @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'additionals']) }}" aria-label="Edit Additional Information"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+    <h2><i class="fas fa-sticky-note" aria-hidden="true"></i> Additional Information @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'additionals']) }}" aria-label="Edit Additional Information"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     @foreach($data as $additional)
         <div class="entry">
-            <h5><i class="far fa-sticky-note" aria-hidden="true"></i> {{$additional->title}}</h5>
+            <h3><i class="far fa-sticky-note" aria-hidden="true"></i> {{$additional->title}}</h3>
                 {!! Purify::clean($additional->description) !!}
         </div>
     @endforeach

--- a/resources/views/livewire/profile-data-cards/affiliations.blade.php
+++ b/resources/views/livewire/profile-data-cards/affiliations.blade.php
@@ -2,7 +2,7 @@
     <h2 id="affiliations-heading"><i class="fas fa-users" aria-hidden="true"></i> Affiliations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'affiliations']) }}" aria-label="Edit Affiliations"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $affiliation)
-            <li class="entry" aria-label="{{$affiliation->title}}">
+            <li class="entry">
                 <h3>{{$affiliation->title}}</h3>
                 @if($affiliation->start_date)<strong>{{$affiliation->start_date}}@if($affiliation->end_date)&ndash;{{$affiliation->end_date}}@endif</strong><br>@endif
                 <p>{!! Purify::clean($affiliation->description) !!}</p>

--- a/resources/views/livewire/profile-data-cards/affiliations.blade.php
+++ b/resources/views/livewire/profile-data-cards/affiliations.blade.php
@@ -1,12 +1,14 @@
 <section id="affiliations" class="card">
     <h2><i class="fas fa-users" aria-hidden="true"></i> Affiliations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'affiliations']) }}" aria-label="Edit Affiliations"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
-    @foreach($data as $affiliation)
-        <div class="entry">
-            <h3>{{$affiliation->title}}</h3>
-            @if($affiliation->start_date)<strong>{{$affiliation->start_date}}@if($affiliation->end_date)&ndash;{{$affiliation->end_date}}@endif</strong><br>@endif
-            {!! Purify::clean($affiliation->description) !!}
-        </div>
-    @endforeach
+    <ul class="list-unstyled">
+        @foreach($data as $affiliation)
+            <li class="entry">
+                <h3>{{$affiliation->title}}</h3>
+                @if($affiliation->start_date)<strong>{{$affiliation->start_date}}@if($affiliation->end_date)&ndash;{{$affiliation->end_date}}@endif</strong><br>@endif
+                {!! Purify::clean($affiliation->description) !!}
+            </li>
+        @endforeach
+    </ul>
     @if($paginated)
         {{ $data->links() }}
     @endif

--- a/resources/views/livewire/profile-data-cards/affiliations.blade.php
+++ b/resources/views/livewire/profile-data-cards/affiliations.blade.php
@@ -1,8 +1,8 @@
 <section id="affiliations" class="card">
-    <h3><i class="fas fa-users" aria-hidden="true"></i> Affiliations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'affiliations']) }}" aria-label="Edit Affiliations"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+    <h2><i class="fas fa-users" aria-hidden="true"></i> Affiliations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'affiliations']) }}" aria-label="Edit Affiliations"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     @foreach($data as $affiliation)
         <div class="entry">
-            <h5>{{$affiliation->title}}</h5>
+            <h3>{{$affiliation->title}}</h3>
             @if($affiliation->start_date)<strong>{{$affiliation->start_date}}@if($affiliation->end_date)&ndash;{{$affiliation->end_date}}@endif</strong><br>@endif
             {!! Purify::clean($affiliation->description) !!}
         </div>

--- a/resources/views/livewire/profile-data-cards/affiliations.blade.php
+++ b/resources/views/livewire/profile-data-cards/affiliations.blade.php
@@ -1,4 +1,4 @@
-<section id="affiliations" role="region" class="card" aria-labelledby="affiliations-heading">
+<section id="affiliations" class="card" aria-labelledby="affiliations-heading">
     <h2 id="affiliations-heading"><i class="fas fa-users" aria-hidden="true"></i> Affiliations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'affiliations']) }}" aria-label="Edit Affiliations"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $affiliation)

--- a/resources/views/livewire/profile-data-cards/affiliations.blade.php
+++ b/resources/views/livewire/profile-data-cards/affiliations.blade.php
@@ -1,11 +1,11 @@
-<section id="affiliations" class="card">
-    <h2><i class="fas fa-users" aria-hidden="true"></i> Affiliations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'affiliations']) }}" aria-label="Edit Affiliations"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
+<section id="affiliations" role="region" class="card" aria-labelledby="affiliations-heading">
+    <h2 id="affiliations-heading"><i class="fas fa-users" aria-hidden="true"></i> Affiliations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'affiliations']) }}" aria-label="Edit Affiliations"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $affiliation)
-            <li class="entry">
+            <li class="entry" aria-label="{{$affiliation->title}}">
                 <h3>{{$affiliation->title}}</h3>
                 @if($affiliation->start_date)<strong>{{$affiliation->start_date}}@if($affiliation->end_date)&ndash;{{$affiliation->end_date}}@endif</strong><br>@endif
-                {!! Purify::clean($affiliation->description) !!}
+                <p>{!! Purify::clean($affiliation->description) !!}</p>
             </li>
         @endforeach
     </ul>

--- a/resources/views/livewire/profile-data-cards/appointments.blade.php
+++ b/resources/views/livewire/profile-data-cards/appointments.blade.php
@@ -1,14 +1,16 @@
-<section id="appointments" class="card">
-    <h2><i class="fa fa-calendar" aria-hidden="true"></i> Appointments @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'appointments']) }}" aria-label="Edit Appointments"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
+<section id="appointments" role="region" class="card" aria-labelledby="appointments-heading">
+    <h2 id="appointments-heading"><i class="fa fa-calendar" aria-hidden="true"></i> Appointments @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'appointments']) }}" aria-label="Edit Appointments"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $appt)
-            <li class="entry">
-                <strong>{{$appt->appointment}}</strong>
-                <br>
-                <em>{{$appt->organization}}</em> [{{$appt->start_date}}@if($appt->end_date)&ndash;{{$appt->end_date}}@else<span>&ndash;Present</span>@endif]<br />
-                @if($appt->description)
-                    {!! Purify::clean($appt->description) !!}
-                @endif
+            <li class="entry" aria-label="{{$appt->appointment}}">
+                <p>
+                    <strong>{{$appt->appointment}}</strong>
+                    <br>
+                    <em>{{$appt->organization}}</em> [{{$appt->start_date}}@if($appt->end_date)&ndash;{{$appt->end_date}}@else<span>&ndash;Present</span>@endif]<br />
+                    @if($appt->description)
+                        {!! Purify::clean($appt->description) !!}
+                    @endif
+                </p>
             </li>
         @endforeach
     </ul>

--- a/resources/views/livewire/profile-data-cards/appointments.blade.php
+++ b/resources/views/livewire/profile-data-cards/appointments.blade.php
@@ -1,5 +1,5 @@
 <section id="appointments" class="card">
-    <h3><i class="fa fa-calendar" aria-hidden="true"></i> Appointments @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'appointments']) }}" aria-label="Edit Appointments"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+    <h2><i class="fa fa-calendar" aria-hidden="true"></i> Appointments @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'appointments']) }}" aria-label="Edit Appointments"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     @foreach($data as $appt)
         <div class="entry">
             <strong>{{$appt->appointment}}</strong>

--- a/resources/views/livewire/profile-data-cards/appointments.blade.php
+++ b/resources/views/livewire/profile-data-cards/appointments.blade.php
@@ -2,7 +2,7 @@
     <h2 id="appointments-heading"><i class="fa fa-calendar" aria-hidden="true"></i> Appointments @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'appointments']) }}" aria-label="Edit Appointments"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $appt)
-            <li class="entry" aria-label="{{$appt->appointment}}">
+            <li class="entry">
                 <p>
                     <strong>{{$appt->appointment}}</strong>
                     <br>

--- a/resources/views/livewire/profile-data-cards/appointments.blade.php
+++ b/resources/views/livewire/profile-data-cards/appointments.blade.php
@@ -1,15 +1,17 @@
 <section id="appointments" class="card">
     <h2><i class="fa fa-calendar" aria-hidden="true"></i> Appointments @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'appointments']) }}" aria-label="Edit Appointments"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
-    @foreach($data as $appt)
-        <div class="entry">
-            <strong>{{$appt->appointment}}</strong>
-            <br>
-            <em>{{$appt->organization}}</em> [{{$appt->start_date}}@if($appt->end_date)&ndash;{{$appt->end_date}}@else<span>&ndash;Present</span>@endif]<br />
-            @if($appt->description)
-                {!! Purify::clean($appt->description) !!}
-            @endif
-        </div>
-    @endforeach
+    <ul class="list-unstyled">
+        @foreach($data as $appt)
+            <li class="entry">
+                <strong>{{$appt->appointment}}</strong>
+                <br>
+                <em>{{$appt->organization}}</em> [{{$appt->start_date}}@if($appt->end_date)&ndash;{{$appt->end_date}}@else<span>&ndash;Present</span>@endif]<br />
+                @if($appt->description)
+                    {!! Purify::clean($appt->description) !!}
+                @endif
+            </li>
+        @endforeach
+    </ul>
     @if($paginated)
         {{ $data->links() }}
     @endif

--- a/resources/views/livewire/profile-data-cards/appointments.blade.php
+++ b/resources/views/livewire/profile-data-cards/appointments.blade.php
@@ -1,4 +1,4 @@
-<section id="appointments" role="region" class="card" aria-labelledby="appointments-heading">
+<section id="appointments" class="card" aria-labelledby="appointments-heading">
     <h2 id="appointments-heading"><i class="fa fa-calendar" aria-hidden="true"></i> Appointments @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'appointments']) }}" aria-label="Edit Appointments"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $appt)

--- a/resources/views/livewire/profile-data-cards/areas.blade.php
+++ b/resources/views/livewire/profile-data-cards/areas.blade.php
@@ -1,8 +1,8 @@
-<section id="areas" class="card">
-    <h2><i class="fas fa-flask" aria-hidden="true"></i> Research Areas @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'areas']) }}" aria-label="Edit Research Areas"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
+<section id="areas" role="region" class="card" aria-labelledby="areas-heading">
+    <h2 id="areas-heading"><i class="fas fa-flask" aria-hidden="true"></i> Research Areas @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'areas']) }}" aria-label="Edit Research Areas"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $area)
-            <li>
+            <li aria-label="{{$area->title}}">
                 @if($area->url)
                     <h3>
                         <a href="{{$area->url}}" target="_blank" class="has-external-link-icon">
@@ -14,7 +14,7 @@
                 @else
                     <h3>{{$area->title}}</h3>
                 @endif
-                {!! Purify::clean($area->description) !!}
+                <p>{!! Purify::clean($area->description) !!}</p>
             </li>
         @endforeach
     </ul>

--- a/resources/views/livewire/profile-data-cards/areas.blade.php
+++ b/resources/views/livewire/profile-data-cards/areas.blade.php
@@ -1,13 +1,17 @@
 <section id="areas" class="card">
     <h2><i class="fas fa-flask" aria-hidden="true"></i> Research Areas @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'areas']) }}" aria-label="Edit Research Areas"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
-    @foreach($data as $area)
-        @if($area->url)
-            <h3><a href="{{$area->url}}">{{$area->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
-        @else
-            <h3>{{$area->title}}</h3>
-        @endif
-        {!! Purify::clean($area->description) !!}
-    @endforeach
+    <ul class="list-unstyled">
+        @foreach($data as $area)
+            <li>
+                @if($area->url)
+                    <h3><a href="{{$area->url}}">{{$area->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
+                @else
+                    <h3>{{$area->title}}</h3>
+                @endif
+                {!! Purify::clean($area->description) !!}
+            </li>
+        @endforeach
+    </ul>
     @if($paginated)
         {{ $data->links() }}
     @endif

--- a/resources/views/livewire/profile-data-cards/areas.blade.php
+++ b/resources/views/livewire/profile-data-cards/areas.blade.php
@@ -1,4 +1,4 @@
-<section id="areas" role="region" class="card" aria-labelledby="areas-heading">
+<section id="areas" class="card" aria-labelledby="areas-heading">
     <h2 id="areas-heading"><i class="fas fa-flask" aria-hidden="true"></i> Research Areas @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'areas']) }}" aria-label="Edit Research Areas"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $area)

--- a/resources/views/livewire/profile-data-cards/areas.blade.php
+++ b/resources/views/livewire/profile-data-cards/areas.blade.php
@@ -4,7 +4,13 @@
         @foreach($data as $area)
             <li>
                 @if($area->url)
-                    <h3><a href="{{$area->url}}">{{$area->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
+                    <h3>
+                        <a href="{{$area->url}}" target="_blank" class="has-external-link-icon">
+                            <span class="has-external-link-icon">{{$area->title}}</span>
+                            <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+                            <span class="sr-only"> (opens in a new tab)</span>
+                        </a>
+                    </h3>
                 @else
                     <h3>{{$area->title}}</h3>
                 @endif

--- a/resources/views/livewire/profile-data-cards/areas.blade.php
+++ b/resources/views/livewire/profile-data-cards/areas.blade.php
@@ -1,10 +1,10 @@
 <section id="areas" class="card">
-    <h3><i class="fas fa-flask" aria-hidden="true"></i> Research Areas @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'areas']) }}" aria-label="Edit Research Areas"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+    <h2><i class="fas fa-flask" aria-hidden="true"></i> Research Areas @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'areas']) }}" aria-label="Edit Research Areas"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     @foreach($data as $area)
         @if($area->url)
-            <h5><a href="{{$area->url}}">{{$area->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h5>
+            <h3><a href="{{$area->url}}">{{$area->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
         @else
-            <h5>{{$area->title}}</h5>
+            <h3>{{$area->title}}</h3>
         @endif
         {!! Purify::clean($area->description) !!}
     @endforeach

--- a/resources/views/livewire/profile-data-cards/areas.blade.php
+++ b/resources/views/livewire/profile-data-cards/areas.blade.php
@@ -2,7 +2,7 @@
     <h2 id="areas-heading"><i class="fas fa-flask" aria-hidden="true"></i> Research Areas @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'areas']) }}" aria-label="Edit Research Areas"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $area)
-            <li aria-label="{{$area->title}}">
+            <li>
                 @if($area->url)
                     <h3>
                         <a href="{{$area->url}}" target="_blank" class="has-external-link-icon">

--- a/resources/views/livewire/profile-data-cards/awards.blade.php
+++ b/resources/views/livewire/profile-data-cards/awards.blade.php
@@ -1,10 +1,12 @@
 <section id="awards" class="card">
     <h2><i class="fa fa-trophy" aria-hidden="true"></i> Awards @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'awards']) }}" aria-label="Edit Awards"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
-    @foreach($data as $award)
-        <div class="entry">
-            <strong>{{$award->name}}</strong> - <em>{{$award->organization}}</em> @if($award->year)[{{$award->year}}]@endif<br />
-        </div>
-    @endforeach
+    <ul class="list-unstyled">
+        @foreach($data as $award)
+            <li class="entry">
+                <strong>{{$award->name}}</strong> - <em>{{$award->organization}}</em> @if($award->year)[{{$award->year}}]@endif<br />
+            </li>
+        @endforeach
+    </ul>
     @if($paginated)
         {{ $data->links() }}
     @endif

--- a/resources/views/livewire/profile-data-cards/awards.blade.php
+++ b/resources/views/livewire/profile-data-cards/awards.blade.php
@@ -2,7 +2,7 @@
     <h2 id="awards-heading"><i class="fa fa-trophy" aria-hidden="true"></i> Awards @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'awards']) }}" aria-label="Edit Awards"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $award)
-            <li class="entry" aria-label="{{$award->name}}">
+            <li class="entry">
                 <p>
                     <strong>{{$award->name}}</strong> - <em>{{$award->organization}}</em> @if($award->year)[{{$award->year}}]@endif<br />
                 </p>

--- a/resources/views/livewire/profile-data-cards/awards.blade.php
+++ b/resources/views/livewire/profile-data-cards/awards.blade.php
@@ -1,9 +1,11 @@
-<section id="awards" class="card">
-    <h2><i class="fa fa-trophy" aria-hidden="true"></i> Awards @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'awards']) }}" aria-label="Edit Awards"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
+<section id="awards" role="region" class="card" aria-labelledby="awards-heading">
+    <h2 id="awards-heading"><i class="fa fa-trophy" aria-hidden="true"></i> Awards @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'awards']) }}" aria-label="Edit Awards"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $award)
-            <li class="entry">
-                <strong>{{$award->name}}</strong> - <em>{{$award->organization}}</em> @if($award->year)[{{$award->year}}]@endif<br />
+            <li class="entry" aria-label="{{$award->name}}">
+                <p>
+                    <strong>{{$award->name}}</strong> - <em>{{$award->organization}}</em> @if($award->year)[{{$award->year}}]@endif<br />
+                </p>
             </li>
         @endforeach
     </ul>

--- a/resources/views/livewire/profile-data-cards/awards.blade.php
+++ b/resources/views/livewire/profile-data-cards/awards.blade.php
@@ -1,4 +1,4 @@
-<section id="awards" role="region" class="card" aria-labelledby="awards-heading">
+<section id="awards" class="card" aria-labelledby="awards-heading">
     <h2 id="awards-heading"><i class="fa fa-trophy" aria-hidden="true"></i> Awards @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'awards']) }}" aria-label="Edit Awards"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $award)

--- a/resources/views/livewire/profile-data-cards/awards.blade.php
+++ b/resources/views/livewire/profile-data-cards/awards.blade.php
@@ -1,5 +1,5 @@
 <section id="awards" class="card">
-    <h3><i class="fa fa-trophy" aria-hidden="true"></i> Awards @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'awards']) }}" aria-label="Edit Awards"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+    <h2><i class="fa fa-trophy" aria-hidden="true"></i> Awards @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'awards']) }}" aria-label="Edit Awards"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     @foreach($data as $award)
         <div class="entry">
             <strong>{{$award->name}}</strong> - <em>{{$award->organization}}</em> @if($award->year)[{{$award->year}}]@endif<br />

--- a/resources/views/livewire/profile-data-cards/news.blade.php
+++ b/resources/views/livewire/profile-data-cards/news.blade.php
@@ -1,4 +1,4 @@
-<section id="news" role="region" class="card" aria-labelledby="news-heading">
+<section id="news" class="card" aria-labelledby="news-heading">
     <h2 id="news-heading"><i class="fas fa-newspaper" aria-hidden="true"></i> News Articles @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'news']) }}" aria-label="Edit News Articles"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $article)

--- a/resources/views/livewire/profile-data-cards/news.blade.php
+++ b/resources/views/livewire/profile-data-cards/news.blade.php
@@ -1,8 +1,8 @@
-<section id="news" class="card">
-    <h2><i class="fas fa-newspaper" aria-hidden="true"></i> News Articles @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'news']) }}" aria-label="Edit News Articles"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
+<section id="news" role="region" class="card" aria-labelledby="news-heading">
+    <h2 id="news-heading"><i class="fas fa-newspaper" aria-hidden="true"></i> News Articles @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'news']) }}" aria-label="Edit News Articles"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $article)
-            <li class="entry">
+            <li class="entry" aria-label="{{$article->title}}">
                 <article>
                     @if($article->url)
                         <h3>
@@ -18,7 +18,7 @@
                     @if($article->image)
                         <img src="{{ $article->imageUrl }}" class="news_image" alt="{{ $article->image_alt ?? $article->title }}"/>
                     @endif
-                    {!! Purify::clean($article->description) !!}
+                    <p>{!! Purify::clean($article->description) !!}</p>
                 </article>
             </li>
         @endforeach

--- a/resources/views/livewire/profile-data-cards/news.blade.php
+++ b/resources/views/livewire/profile-data-cards/news.blade.php
@@ -6,14 +6,18 @@
                 <article>
                     @if($article->url)
                         <h3>
-                            <a href="{{$article->url}}" target="_blank" title="link to article">
-                                {{$article->title}} <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+                            <a href="{{$article->url}}" target="_blank" class="has-external-link-icon">
+                                <span class="has-external-link-icon">{{$article->title}}</span>
+                                <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+                                <span class="sr-only"> (opens in a new tab)</span>
                             </a>
                         </h3>
                     @else
                         <h3>{{$article->title}}</h3>
                     @endif
-                    @if($article->image)<img src="{{ $article->imageUrl }}" class="news_image" alt="{{ $article->image_alt ?? $article->title }}"/>@endif
+                    @if($article->image)
+                        <img src="{{ $article->imageUrl }}" class="news_image" alt="{{ $article->image_alt ?? $article->title }}"/>
+                    @endif
                     {!! Purify::clean($article->description) !!}
                 </article>
             </li>

--- a/resources/views/livewire/profile-data-cards/news.blade.php
+++ b/resources/views/livewire/profile-data-cards/news.blade.php
@@ -1,15 +1,15 @@
 <section id="news" class="card">
-    <h3><i class="fas fa-newspaper" aria-hidden="true"></i> News Articles @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'news']) }}" aria-label="Edit News Articles"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+    <h2><i class="fas fa-newspaper" aria-hidden="true"></i> News Articles @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'news']) }}" aria-label="Edit News Articles"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     @foreach($data as $article)
         <div class="entry">
             @if($article->url)
-                <h5>
+                <h3>
                     <a href="{{$article->url}}" target="_blank" title="link to article">
                         {{$article->title}} <i class="fas fa-external-link-alt" aria-hidden="true"></i>
                     </a>
-                </h5>
+                </h3>
             @else
-                <h5>{{$article->title}}</h5>
+                <h3>{{$article->title}}</h3>
             @endif
             @if($article->image)<img src="{{ $article->imageUrl }}" class="news_image" alt="{{ $article->image_alt ?? $article->title }}"/>@endif
             {!! Purify::clean($article->description) !!}

--- a/resources/views/livewire/profile-data-cards/news.blade.php
+++ b/resources/views/livewire/profile-data-cards/news.blade.php
@@ -1,20 +1,24 @@
 <section id="news" class="card">
     <h2><i class="fas fa-newspaper" aria-hidden="true"></i> News Articles @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'news']) }}" aria-label="Edit News Articles"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
-    @foreach($data as $article)
-        <div class="entry">
-            @if($article->url)
-                <h3>
-                    <a href="{{$article->url}}" target="_blank" title="link to article">
-                        {{$article->title}} <i class="fas fa-external-link-alt" aria-hidden="true"></i>
-                    </a>
-                </h3>
-            @else
-                <h3>{{$article->title}}</h3>
-            @endif
-            @if($article->image)<img src="{{ $article->imageUrl }}" class="news_image" alt="{{ $article->image_alt ?? $article->title }}"/>@endif
-            {!! Purify::clean($article->description) !!}
-        </div>
-    @endforeach
+    <ul class="list-unstyled">
+        @foreach($data as $article)
+            <li class="entry">
+                <article>
+                    @if($article->url)
+                        <h3>
+                            <a href="{{$article->url}}" target="_blank" title="link to article">
+                                {{$article->title}} <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+                            </a>
+                        </h3>
+                    @else
+                        <h3>{{$article->title}}</h3>
+                    @endif
+                    @if($article->image)<img src="{{ $article->imageUrl }}" class="news_image" alt="{{ $article->image_alt ?? $article->title }}"/>@endif
+                    {!! Purify::clean($article->description) !!}
+                </article>
+            </li>
+        @endforeach
+    </ul>
     @if($paginated)
         {{ $data->links() }}
     @endif

--- a/resources/views/livewire/profile-data-cards/news.blade.php
+++ b/resources/views/livewire/profile-data-cards/news.blade.php
@@ -2,7 +2,7 @@
     <h2 id="news-heading"><i class="fas fa-newspaper" aria-hidden="true"></i> News Articles @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'news']) }}" aria-label="Edit News Articles"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $article)
-            <li class="entry" aria-label="{{$article->title}}">
+            <li class="entry">
                 <article>
                     @if($article->url)
                         <h3>

--- a/resources/views/livewire/profile-data-cards/preparation.blade.php
+++ b/resources/views/livewire/profile-data-cards/preparation.blade.php
@@ -1,11 +1,13 @@
-<section id="preparation" class="card">
-    <h2><i class="fas fa-graduation-cap" aria-hidden="true"></i> Professional Preparation @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'preparation']) }}" aria-label="Edit Professional Preparation"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
+<section id="preparation" role="region" class="card" aria-labelledby="preparation-heading">
+    <h2 id="preparation-heading"><i class="fas fa-graduation-cap" aria-hidden="true"></i> Professional Preparation @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'preparation']) }}" aria-label="Edit Professional Preparation"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $prep)
-            <li class="entry">
-                {{$prep->degree}} @if($prep->major)- {{$prep->major}}@endif
-                <br>
-                <strong>{{$prep->institution}}</strong>@if($prep->year) - {{$prep->year}}@endif
+            <li class="entry" aria-label="{{$prep->degree}}">
+                <p>
+                    {{$prep->degree}} @if($prep->major)- {{$prep->major}}@endif
+                    <br>
+                    <strong>{{$prep->institution}}</strong>@if($prep->year) - {{$prep->year}}@endif
+                </p>
             </li>
         @endforeach
     </ul>

--- a/resources/views/livewire/profile-data-cards/preparation.blade.php
+++ b/resources/views/livewire/profile-data-cards/preparation.blade.php
@@ -1,4 +1,4 @@
-<section id="preparation" role="region" class="card" aria-labelledby="preparation-heading">
+<section id="preparation" class="card" aria-labelledby="preparation-heading">
     <h2 id="preparation-heading"><i class="fas fa-graduation-cap" aria-hidden="true"></i> Professional Preparation @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'preparation']) }}" aria-label="Edit Professional Preparation"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $prep)

--- a/resources/views/livewire/profile-data-cards/preparation.blade.php
+++ b/resources/views/livewire/profile-data-cards/preparation.blade.php
@@ -1,12 +1,14 @@
 <section id="preparation" class="card">
     <h2><i class="fas fa-graduation-cap" aria-hidden="true"></i> Professional Preparation @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'preparation']) }}" aria-label="Edit Professional Preparation"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
-    @foreach($data as $prep)
-        <div class="entry">
-            {{$prep->degree}} @if($prep->major)- {{$prep->major}}@endif
-            <br>
-            <strong>{{$prep->institution}}</strong>@if($prep->year) - {{$prep->year}}@endif
-        </div>
-    @endforeach
+    <ul class="list-unstyled">
+        @foreach($data as $prep)
+            <li class="entry">
+                {{$prep->degree}} @if($prep->major)- {{$prep->major}}@endif
+                <br>
+                <strong>{{$prep->institution}}</strong>@if($prep->year) - {{$prep->year}}@endif
+            </li>
+        @endforeach
+    </ul>
     @if($paginated)
         {{ $data->links() }}
     @endif

--- a/resources/views/livewire/profile-data-cards/preparation.blade.php
+++ b/resources/views/livewire/profile-data-cards/preparation.blade.php
@@ -1,5 +1,5 @@
 <section id="preparation" class="card">
-    <h3><i class="fas fa-graduation-cap" aria-hidden="true"></i> Professional Preparation @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'preparation']) }}" aria-label="Edit Professional Preparation"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+    <h2><i class="fas fa-graduation-cap" aria-hidden="true"></i> Professional Preparation @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'preparation']) }}" aria-label="Edit Professional Preparation"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     @foreach($data as $prep)
         <div class="entry">
             {{$prep->degree}} @if($prep->major)- {{$prep->major}}@endif

--- a/resources/views/livewire/profile-data-cards/preparation.blade.php
+++ b/resources/views/livewire/profile-data-cards/preparation.blade.php
@@ -2,7 +2,7 @@
     <h2 id="preparation-heading"><i class="fas fa-graduation-cap" aria-hidden="true"></i> Professional Preparation @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'preparation']) }}" aria-label="Edit Professional Preparation"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $prep)
-            <li class="entry" aria-label="{{$prep->degree}}">
+            <li class="entry">
                 <p>
                     {{$prep->degree}} @if($prep->major)- {{$prep->major}}@endif
                     <br>

--- a/resources/views/livewire/profile-data-cards/presentations.blade.php
+++ b/resources/views/livewire/profile-data-cards/presentations.blade.php
@@ -1,18 +1,22 @@
 <section id="presentations" class="card">
     <h2><i class="fas fa-laptop" aria-hidden="true"></i> Presentations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'presentations']) }}" aria-label="Edit Presentations"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
-    @foreach($data as $presentation)
-        <div class="entry">
-            @if($presentation->url)
-                <h3><a href="{{$presentation->url}}">{{$presentation->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
-            @else
-                <h3>{{$presentation->title}}</h3>
-            @endif
-            @if($presentation->start_date)<strong>{{$presentation->start_date}}@if($presentation->end_date)&ndash;{{$presentation->end_date}}@endif</strong>@endif
-            @if($presentation->description)
-                <em>{!! Purify::clean($presentation->description) !!}</em>
-            @endif
-        </div>
-    @endforeach
+    <ul class="list-unstyled">
+        @foreach($data as $presentation)
+            <li class="entry">
+                <article>
+                    @if($presentation->url)
+                        <h3><a href="{{$presentation->url}}">{{$presentation->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
+                    @else
+                        <h3>{{$presentation->title}}</h3>
+                    @endif
+                    @if($presentation->start_date)<strong>{{$presentation->start_date}}@if($presentation->end_date)&ndash;{{$presentation->end_date}}@endif</strong>@endif
+                    @if($presentation->description)
+                        <em>{!! Purify::clean($presentation->description) !!}</em>
+                    @endif
+                </article>
+            </li>
+        @endforeach
+    </ul>
     @if($paginated)
         {{ $data->links() }}
     @endif

--- a/resources/views/livewire/profile-data-cards/presentations.blade.php
+++ b/resources/views/livewire/profile-data-cards/presentations.blade.php
@@ -2,7 +2,7 @@
     <h2 id="presentations-heading"><i class="fas fa-laptop" aria-hidden="true"></i> Presentations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'presentations']) }}" aria-label="Edit Presentations"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $presentation)
-            <li class="entry" aria-label="{{$presentation->title}}">
+            <li class="entry">
                 <article>
                     @if($presentation->url)
                     <h3>

--- a/resources/views/livewire/profile-data-cards/presentations.blade.php
+++ b/resources/views/livewire/profile-data-cards/presentations.blade.php
@@ -1,11 +1,11 @@
 <section id="presentations" class="card">
-    <h3><i class="fas fa-laptop" aria-hidden="true"></i> Presentations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'presentations']) }}" aria-label="Edit Presentations"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+    <h2><i class="fas fa-laptop" aria-hidden="true"></i> Presentations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'presentations']) }}" aria-label="Edit Presentations"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     @foreach($data as $presentation)
         <div class="entry">
             @if($presentation->url)
-                <h5><a href="{{$presentation->url}}">{{$presentation->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h5>
+                <h3><a href="{{$presentation->url}}">{{$presentation->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
             @else
-                <h5>{{$presentation->title}}</h5>
+                <h3>{{$presentation->title}}</h3>
             @endif
             @if($presentation->start_date)<strong>{{$presentation->start_date}}@if($presentation->end_date)&ndash;{{$presentation->end_date}}@endif</strong>@endif
             @if($presentation->description)

--- a/resources/views/livewire/profile-data-cards/presentations.blade.php
+++ b/resources/views/livewire/profile-data-cards/presentations.blade.php
@@ -5,11 +5,23 @@
             <li class="entry">
                 <article>
                     @if($presentation->url)
-                        <h3><a href="{{$presentation->url}}">{{$presentation->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
+                    <h3>
+                        <a href="{{$presentation->url}}" target="_blank" class="has-external-link-icon">
+                            <span class="has-external-link-icon">{{$presentation->title}}</span>
+                            <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+                            <span class="sr-only"> (opens in a new tab)</span>
+                        </a>
+                    </h3>
                     @else
                         <h3>{{$presentation->title}}</h3>
                     @endif
-                    @if($presentation->start_date)<strong>{{$presentation->start_date}}@if($presentation->end_date)&ndash;{{$presentation->end_date}}@endif</strong>@endif
+                    @if($presentation->start_date)
+                        <strong>{{$presentation->start_date}}
+                            @if($presentation->end_date)
+                                &ndash;{{$presentation->end_date}}
+                            @endif
+                        </strong>
+                    @endif
                     @if($presentation->description)
                         <em>{!! Purify::clean($presentation->description) !!}</em>
                     @endif

--- a/resources/views/livewire/profile-data-cards/presentations.blade.php
+++ b/resources/views/livewire/profile-data-cards/presentations.blade.php
@@ -1,8 +1,8 @@
-<section id="presentations" class="card">
-    <h2><i class="fas fa-laptop" aria-hidden="true"></i> Presentations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'presentations']) }}" aria-label="Edit Presentations"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
+<section id="presentations" role="region" class="card" aria-labelledby="presentations-heading">
+    <h2 id="presentations-heading"><i class="fas fa-laptop" aria-hidden="true"></i> Presentations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'presentations']) }}" aria-label="Edit Presentations"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $presentation)
-            <li class="entry">
+            <li class="entry" aria-label="{{$presentation->title}}">
                 <article>
                     @if($presentation->url)
                     <h3>

--- a/resources/views/livewire/profile-data-cards/presentations.blade.php
+++ b/resources/views/livewire/profile-data-cards/presentations.blade.php
@@ -1,4 +1,4 @@
-<section id="presentations" role="region" class="card" aria-labelledby="presentations-heading">
+<section id="presentations" class="card" aria-labelledby="presentations-heading">
     <h2 id="presentations-heading"><i class="fas fa-laptop" aria-hidden="true"></i> Presentations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'presentations']) }}" aria-label="Edit Presentations"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $presentation)

--- a/resources/views/livewire/profile-data-cards/projects.blade.php
+++ b/resources/views/livewire/profile-data-cards/projects.blade.php
@@ -1,4 +1,4 @@
-<section id="projects" role="region" class="card" aria-labelledby="projects-heading">
+<section id="projects" class="card" aria-labelledby="projects-heading">
     <h2 id="projects-heading"><i class="fas fa-tasks" aria-hidden="true"></i> Projects @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'projects']) }}" aria-label="Edit Projects"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $project)

--- a/resources/views/livewire/profile-data-cards/projects.blade.php
+++ b/resources/views/livewire/profile-data-cards/projects.blade.php
@@ -5,7 +5,13 @@
             <li class="entry">
                 <article>
                     @if($project->url)
-                        <h3><a href="{{$project->url}}">{{$project->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
+                        <h3>
+                            <a href="{{$project->url}}" target="_blank" class="has-external-link-icon">
+                                <span class="has-external-link-icon">{{$project->title}}</span>
+                                <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+                                <span class="sr-only"> (opens in a new tab)</span>
+                            </a>
+                        </h3>
                     @else
                         <h3>{{$project->title}}</h3>
                     @endif

--- a/resources/views/livewire/profile-data-cards/projects.blade.php
+++ b/resources/views/livewire/profile-data-cards/projects.blade.php
@@ -1,18 +1,22 @@
 <section id="projects" class="card">
     <h2><i class="fas fa-tasks" aria-hidden="true"></i> Projects @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'projects']) }}" aria-label="Edit Projects"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
-    @foreach($data as $project)
-        <div class="entry">
-            @if($project->url)
-                <h3><a href="{{$project->url}}">{{$project->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
-            @else
-                <h3>{{$project->title}}</h3>
-            @endif
-            @if($project->start_date)<strong>{{$project->start_date}}@if($project->end_date)&ndash;{{$project->end_date}}@endif</strong>@endif
-            @if($project->description)
-                <em>{!! Purify::clean($project->description) !!}</em>
-            @endif
-        </div>
-    @endforeach
+    <ul class="list-unstyled">
+        @foreach($data as $project)
+            <li class="entry">
+                <article>
+                    @if($project->url)
+                        <h3><a href="{{$project->url}}">{{$project->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
+                    @else
+                        <h3>{{$project->title}}</h3>
+                    @endif
+                    @if($project->start_date)<strong>{{$project->start_date}}@if($project->end_date)&ndash;{{$project->end_date}}@endif</strong>@endif
+                    @if($project->description)
+                        <em>{!! Purify::clean($project->description) !!}</em>
+                    @endif
+                </article>
+            </li>
+        @endforeach
+    </ul>
     @if($paginated)
         {{ $data->links() }}
     @endif

--- a/resources/views/livewire/profile-data-cards/projects.blade.php
+++ b/resources/views/livewire/profile-data-cards/projects.blade.php
@@ -1,8 +1,8 @@
-<section id="projects" class="card">
-    <h2><i class="fas fa-tasks" aria-hidden="true"></i> Projects @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'projects']) }}" aria-label="Edit Projects"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
+<section id="projects" role="region" class="card" aria-labelledby="projects-heading">
+    <h2 id="projects-heading"><i class="fas fa-tasks" aria-hidden="true"></i> Projects @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'projects']) }}" aria-label="Edit Projects"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $project)
-            <li class="entry">
+            <li class="entry" aria-label="{{$project->title}}">
                 <article>
                     @if($project->url)
                         <h3>

--- a/resources/views/livewire/profile-data-cards/projects.blade.php
+++ b/resources/views/livewire/profile-data-cards/projects.blade.php
@@ -2,7 +2,7 @@
     <h2 id="projects-heading"><i class="fas fa-tasks" aria-hidden="true"></i> Projects @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'projects']) }}" aria-label="Edit Projects"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $project)
-            <li class="entry" aria-label="{{$project->title}}">
+            <li class="entry">
                 <article>
                     @if($project->url)
                         <h3>

--- a/resources/views/livewire/profile-data-cards/projects.blade.php
+++ b/resources/views/livewire/profile-data-cards/projects.blade.php
@@ -1,11 +1,11 @@
 <section id="projects" class="card">
-    <h3><i class="fas fa-tasks" aria-hidden="true"></i> Projects @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'projects']) }}" aria-label="Edit Projects"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+    <h2><i class="fas fa-tasks" aria-hidden="true"></i> Projects @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'projects']) }}" aria-label="Edit Projects"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     @foreach($data as $project)
         <div class="entry">
             @if($project->url)
-                <h5><a href="{{$project->url}}">{{$project->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h5>
+                <h3><a href="{{$project->url}}">{{$project->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
             @else
-                <h5>{{$project->title}}</h5>
+                <h3>{{$project->title}}</h3>
             @endif
             @if($project->start_date)<strong>{{$project->start_date}}@if($project->end_date)&ndash;{{$project->end_date}}@endif</strong>@endif
             @if($project->description)

--- a/resources/views/livewire/profile-data-cards/publications.blade.php
+++ b/resources/views/livewire/profile-data-cards/publications.blade.php
@@ -13,11 +13,15 @@
     <ul class="list-unstyled">
         @foreach($data as $pub)
             <li class="entry">
-                {!! Purify::clean($pub->title) !!} {{$pub->year}} - <strong>{{$pub->type}}</strong>
                 @if($pub->url)
-                    <a target="_blank" href="{{$pub->url}}">
-                        <span class="fas fa-external-link-alt" title="external link to publication"></span>
+                    <a target="_blank" href="{{$pub->url}}" class="has-external-link-icon">
+                        <span class="has-external-link-icon">{!! Purify::clean($pub->title) !!} {{$pub->year}}</span>
+                        <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+                        <span class="sr-only"> (opens in a new tab)</span>
                     </a>
+                    <strong>{{$pub->type}}</strong>
+                @else
+                    {!! Purify::clean($pub->title) !!} {{$pub->year}} - <strong>{{$pub->type}}</strong></>
                 @endif
             </li>
         @endforeach

--- a/resources/views/livewire/profile-data-cards/publications.blade.php
+++ b/resources/views/livewire/profile-data-cards/publications.blade.php
@@ -1,5 +1,5 @@
 <section id="publications" class="card">
-    <h3><i class="fa fa-book" aria-hidden="true"></i> Publications
+    <h2><i class="fa fa-book" aria-hidden="true"></i> Publications
         @if($editable)
         <a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'publications']) }}" data-toggle="class" data-toggle-class="fa-spin" data-target="#publications .fa-sync">
             @if($profile->hasOrcidManagedPublications())
@@ -9,7 +9,7 @@
             @endif
         </a>
         @endif
-    </h3>
+    </h2>
     @foreach($data as $pub)
         <div class="entry">
             {!! Purify::clean($pub->title) !!} {{$pub->year}} - <strong>{{$pub->type}}</strong>

--- a/resources/views/livewire/profile-data-cards/publications.blade.php
+++ b/resources/views/livewire/profile-data-cards/publications.blade.php
@@ -1,5 +1,5 @@
-<section id="publications" class="card">
-    <h2><i class="fa fa-book" aria-hidden="true"></i> Publications
+<section id="publications" role="region" class="card" aria-labelledby="publications-heading">
+    <h2 id="publications-heading"><i class="fa fa-book" aria-hidden="true"></i> Publications
         @if($editable)
         <a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'publications']) }}" data-toggle="class" data-toggle-class="fa-spin" data-target="#publications .fa-sync">
             @if($profile->hasOrcidManagedPublications())
@@ -12,7 +12,7 @@
     </h2>
     <ul class="list-unstyled">
         @foreach($data as $pub)
-            <li class="entry">
+            <li class="entry" aria-label="{{$pub->title}}">
                 @if($pub->url)
                     <a target="_blank" href="{{$pub->url}}" class="has-external-link-icon">
                         <span class="has-external-link-icon">{!! Purify::clean($pub->title) !!} {{$pub->year}}</span>

--- a/resources/views/livewire/profile-data-cards/publications.blade.php
+++ b/resources/views/livewire/profile-data-cards/publications.blade.php
@@ -1,4 +1,4 @@
-<section id="publications" role="region" class="card" aria-labelledby="publications-heading">
+<section id="publications" class="card" aria-labelledby="publications-heading">
     <h2 id="publications-heading"><i class="fa fa-book" aria-hidden="true"></i> Publications
         @if($editable)
         <a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'publications']) }}" data-toggle="class" data-toggle-class="fa-spin" data-target="#publications .fa-sync">

--- a/resources/views/livewire/profile-data-cards/publications.blade.php
+++ b/resources/views/livewire/profile-data-cards/publications.blade.php
@@ -12,7 +12,7 @@
     </h2>
     <ul class="list-unstyled">
         @foreach($data as $pub)
-            <li class="entry" aria-label="{{$pub->title}}">
+            <li class="entry">
                 @if($pub->url)
                     <a target="_blank" href="{{$pub->url}}" class="has-external-link-icon">
                         <span class="has-external-link-icon">{!! Purify::clean($pub->title) !!}</span>

--- a/resources/views/livewire/profile-data-cards/publications.blade.php
+++ b/resources/views/livewire/profile-data-cards/publications.blade.php
@@ -15,13 +15,13 @@
             <li class="entry" aria-label="{{$pub->title}}">
                 @if($pub->url)
                     <a target="_blank" href="{{$pub->url}}" class="has-external-link-icon">
-                        <span class="has-external-link-icon">{!! Purify::clean($pub->title) !!} {{$pub->year}}</span>
+                        <span class="has-external-link-icon">{!! Purify::clean($pub->title) !!}</span>
                         <i class="fas fa-external-link-alt" aria-hidden="true"></i>
                         <span class="sr-only"> (opens in a new tab)</span>
                     </a>
-                    <strong>{{$pub->type}}</strong>
+                    {{$pub->year}} - {{$pub->type}}
                 @else
-                    {!! Purify::clean($pub->title) !!} {{$pub->year}} - <strong>{{$pub->type}}</strong></>
+                    {!! Purify::clean($pub->title) !!} {{$pub->year}} - {{$pub->type}}
                 @endif
             </li>
         @endforeach

--- a/resources/views/livewire/profile-data-cards/publications.blade.php
+++ b/resources/views/livewire/profile-data-cards/publications.blade.php
@@ -10,16 +10,18 @@
         </a>
         @endif
     </h2>
-    @foreach($data as $pub)
-        <div class="entry">
-            {!! Purify::clean($pub->title) !!} {{$pub->year}} - <strong>{{$pub->type}}</strong>
-            @if($pub->url)
-                <a target="_blank" href="{{$pub->url}}">
-                    <span class="fas fa-external-link-alt" title="external link to publication"></span>
-                </a>
-            @endif
-        </div>
-    @endforeach
+    <ul class="list-unstyled">
+        @foreach($data as $pub)
+            <li class="entry">
+                {!! Purify::clean($pub->title) !!} {{$pub->year}} - <strong>{{$pub->type}}</strong>
+                @if($pub->url)
+                    <a target="_blank" href="{{$pub->url}}">
+                        <span class="fas fa-external-link-alt" title="external link to publication"></span>
+                    </a>
+                @endif
+            </li>
+        @endforeach
+    </ul>
     @if($paginated)
         {{ $data->links() }}
     @endif

--- a/resources/views/livewire/profile-data-cards/support.blade.php
+++ b/resources/views/livewire/profile-data-cards/support.blade.php
@@ -1,16 +1,18 @@
 <section id="funding" class="card">
     <h2><i class="fas fa-dollar-sign" aria-hidden="true"></i> Funding @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'support']) }}" aria-label="Edit Funding"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
-    @foreach($data as $funding)
-        <div class="entry">
-            @if($funding->url)
-                <h3><a href="{{$funding->url}}">{{$funding->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
-            @else
-                <h3>{{$funding->title}}</h3>
-            @endif
-            <h4>{{$funding->amount}} - {{$funding->sponsor}} [{{$funding->start_date}}@if($funding->end_date)&ndash;{{$funding->end_date}}@endif]</h4>
-            {{ $funding->description }}
-        </div>
-    @endforeach
+    <ul class="list-unstyled">
+        @foreach($data as $funding)
+            <li class="entry">
+                @if($funding->url)
+                    <h3><a href="{{$funding->url}}">{{$funding->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
+                @else
+                    <h3>{{$funding->title}}</h3>
+                @endif
+                <h4>{{$funding->amount}} - {{$funding->sponsor}} [{{$funding->start_date}}@if($funding->end_date)&ndash;{{$funding->end_date}}@endif]</h4>
+                {{ $funding->description }}
+            </li>
+        @endforeach
+    </ul>
     @if($paginated)
         {{ $data->links() }}
     @endif

--- a/resources/views/livewire/profile-data-cards/support.blade.php
+++ b/resources/views/livewire/profile-data-cards/support.blade.php
@@ -4,7 +4,13 @@
         @foreach($data as $funding)
             <li class="entry">
                 @if($funding->url)
-                    <h3><a href="{{$funding->url}}">{{$funding->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
+                    <h3>
+                        <a href="{{$funding->url}}" target="_blank" class="has-external-link-icon">
+                            <span class="has-external-link-icon">{{$funding->title}}</span>
+                            <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+                            <span class="sr-only"> (opens in a new tab)</span>
+                        </a>
+                    </h3>
                 @else
                     <h3>{{$funding->title}}</h3>
                 @endif

--- a/resources/views/livewire/profile-data-cards/support.blade.php
+++ b/resources/views/livewire/profile-data-cards/support.blade.php
@@ -2,7 +2,7 @@
     <h2 id="funding-heading"><i class="fas fa-dollar-sign" aria-hidden="true"></i> Funding @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'support']) }}" aria-label="Edit Funding"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $funding)
-            <li class="entry" aria-label="{{$funding->title}}">
+            <li class="entry">
                 @if($funding->url)
                     <h3>
                         <a href="{{$funding->url}}" target="_blank" class="has-external-link-icon">

--- a/resources/views/livewire/profile-data-cards/support.blade.php
+++ b/resources/views/livewire/profile-data-cards/support.blade.php
@@ -1,13 +1,13 @@
 <section id="funding" class="card">
-    <h3><i class="fas fa-dollar-sign" aria-hidden="true"></i> Funding @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'support']) }}" aria-label="Edit Funding"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+    <h2><i class="fas fa-dollar-sign" aria-hidden="true"></i> Funding @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'support']) }}" aria-label="Edit Funding"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     @foreach($data as $funding)
         <div class="entry">
             @if($funding->url)
-                <h5><a href="{{$funding->url}}">{{$funding->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h5>
+                <h3><a href="{{$funding->url}}">{{$funding->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h3>
             @else
-                <h5>{{$funding->title}}</h5>
+                <h3>{{$funding->title}}</h3>
             @endif
-            <h6>{{$funding->amount}} - {{$funding->sponsor}} [{{$funding->start_date}}@if($funding->end_date)&ndash;{{$funding->end_date}}@endif]</h6>
+            <h4>{{$funding->amount}} - {{$funding->sponsor}} [{{$funding->start_date}}@if($funding->end_date)&ndash;{{$funding->end_date}}@endif]</h4>
             {{ $funding->description }}
         </div>
     @endforeach

--- a/resources/views/livewire/profile-data-cards/support.blade.php
+++ b/resources/views/livewire/profile-data-cards/support.blade.php
@@ -1,8 +1,8 @@
-<section id="funding" class="card">
-    <h2><i class="fas fa-dollar-sign" aria-hidden="true"></i> Funding @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'support']) }}" aria-label="Edit Funding"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
+<section id="funding" role="region" class="card" aria-labelledby="funding-heading">
+    <h2 id="funding-heading"><i class="fas fa-dollar-sign" aria-hidden="true"></i> Funding @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'support']) }}" aria-label="Edit Funding"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $funding)
-            <li class="entry">
+            <li class="entry" aria-label="{{$funding->title}}">
                 @if($funding->url)
                     <h3>
                         <a href="{{$funding->url}}" target="_blank" class="has-external-link-icon">

--- a/resources/views/livewire/profile-data-cards/support.blade.php
+++ b/resources/views/livewire/profile-data-cards/support.blade.php
@@ -1,4 +1,4 @@
-<section id="funding" role="region" class="card" aria-labelledby="funding-heading">
+<section id="funding" class="card" aria-labelledby="funding-heading">
     <h2 id="funding-heading"><i class="fas fa-dollar-sign" aria-hidden="true"></i> Funding @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'support']) }}" aria-label="Edit Funding"><i class="fas fa-edit"></i> Edit</a>@endif</h2>
     <ul class="list-unstyled">
         @foreach($data as $funding)


### PR DESCRIPTION
Addresses the majority of the issues reported in the [Atlas ticket #745306](https://atlas.utdallas.edu/TDNext/Apps/38/Tickets/TicketDet?TicketID=745306) including reader navigation and WCAG compliance issues across all profile section templates, including:

1. **Skipped Heading Levels**
   - Changed H3 headings to H2 for all sections to maintain proper heading hierarchy after the H1 profile name
   - Changed H5 headings to H3 in: activities, additionals, affiliations, areas, news, projects, presentations, and support sections
   - Changed H6 to H4 in the support section

2. **Non-Semantic HTML Elements**
   - Replaced `<div>` elements with proper `<ul>` and `<li>` lists in: additionals, affiliations, appointments, areas, awards, preparation, publications, and support sections
   - Used `<ul>` → `<li>` → `<article>` structure for: activities, news, projects, and presentations sections
   - ~~Added `aria-label` to list items in all sections to prevent screen readers from announcing long headings twice~~
   - Added `<p>` tags in all sections to to prevent screen readers from announcing long headings twice and the entire element content

3. **External Link Icon:** For the additionals, areas, news, presentations, publications, projects and support sections:
   - Moved external links from icons to article/publication titles
   - Added `has-external-link-icon` class to fix underline styling for links with external link icons
   - Added "opens in new tab" screen reader-only text to external links in the same sections

Replaces PR #212 for file reorganization. 