### PR TITLE
Add Image Filename Length Validation for Profile, Banner, and News Article Uploads

### DIFF
--- a/app/Http/Requests/Concerns/HasImageUploads.php
+++ b/app/Http/Requests/Concerns/HasImageUploads.php
@@ -2,14 +2,21 @@
 
 namespace App\Http\Requests\Concerns;
 
+use App\Rules\FilenameLengthRule;
+
 trait HasImageUploads
 {
-    public function uploadedImageRules(): string
+    public function uploadedImageRules(): array
     {
         $max_filesize = $this->maxFilesize() * 1000;
         $allowed_mimes = implode(',', $this->supportedMimes());
 
-        return "mimes:$allowed_mimes|min:1|max:$max_filesize";
+        return [
+            "mimes:{$allowed_mimes}",
+            "min:1",
+            "max:{$max_filesize}",
+            new FilenameLengthRule(maxLength: 200),
+        ];
     }
 
     public function uploadedImageMessages(string $rule): string

--- a/app/Rules/FilenameLengthRule.php
+++ b/app/Rules/FilenameLengthRule.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Http\UploadedFile;
+
+class FilenameLengthRule implements ValidationRule
+{
+    public function __construct(private int $maxLength = 100) {}
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! $value instanceof UploadedFile) {
+            return;
+        }
+
+        $name = $value->getClientOriginalName();
+
+        if (strlen($name) > $this->maxLength) {
+            $fail("The :attribute filename must not exceed {$this->maxLength} characters.");
+        }
+    }
+}

--- a/resources/views/profiles/edit/information.blade.php
+++ b/resources/views/profiles/edit/information.blade.php
@@ -6,6 +6,12 @@
 			<label for="file">Icon</label>
 			<img id="file-img" class="profile_photo" src="{{ $profile->imageUrl }}" />
 			<br />
+			<small class="form-text text-muted"> Image requirements <a role="button" tabindex="0" aria-label="image requirements information" data-toggle="popover" data-trigger="focus" data-popover-content="#img-rules"><i class="fas fa-question-circle"></i></a></small>
+			<div id="img-rules" style="display:none">
+				<p class="m-1"><small>Supported file types: JPEG, PNG, GIF, BMP, SVG, and WebP.</small></p>
+				<p class="m-1"><small>Maximum file size: 10 MB.</small></p>
+				<p class="m-1"><small>Maximum file name lentgh: 200 characters.</small></p>
+			</div>
 			<br />
 			<div class="control-group">
 				<div class="controls">
@@ -24,6 +30,7 @@
 			<label for="banner">Banner</label>
 			<img id="banner-img" class="profile_photo" src="{{ $profile->banner_url }}" />
 			<br />
+				<small class="form-text text-muted"> Image requirements <a role="button" tabindex="0" aria-label="image requirements information" data-toggle="popover" data-trigger="focus" data-popover-content="#img-rules"><i class="fas fa-question-circle"></i></a></small>
 			<br />
 			<div class="control-group">
 				<div class="controls">

--- a/resources/views/profiles/edit/news.blade.php
+++ b/resources/views/profiles/edit/news.blade.php
@@ -37,7 +37,7 @@
                 <label for="data[{{ $news->id }}][image]-img">Image</label>
                 <img class="uploaded-image w-100 d-flex" id="data[{{ $news->id }}][image]-img"
                     src="@if ($news->imageUrl != asset('/img/default.png')) {{ $news->imageUrl }} @endif">
-                <div class="custom-file form-control">
+                <div class="custom-file form-control" style="margin-bottom: 0px!important;">
                     <input type="file" id="data[{{ $news->id }}][image]" name="data[{{ $news->id }}][image]"
                         accept="image/*" class="custom-file-input clickable">
                     <label id="label-{{ $news->id }}" for="data[{{ $news->id }}][image]"
@@ -45,6 +45,12 @@
                         {{ $news->image->file_name ?? 'Select an image' }}
                     </label>
                 </div>
+                <small class="form-text text-muted"> Image requirements <a role="button" tabindex="0" aria-label="image requirements information" data-toggle="popover" data-trigger="focus" data-popover-content="#img-rules"><i class="fas fa-question-circle"></i></a></small>
+                <div id="img-rules" style="display:none">
+                    <p class="m-1"><small>Supported file types: JPEG, PNG, GIF, BMP, SVG, and WebP.</small></p>
+                    <p class="m-1"><small>Maximum file size: 10 MB.</small></p>
+                    <p class="m-1"><small>Maximum file name lentgh: 200 characters.</small></p>
+	    		</div>
                 @foreach ($errors->get("data.{$news->id}.image") as $image_error)
                     @include('alert', ['message' => $image_error, 'type' => 'danger'])
                     <p class="d-block invalid-feedback"><i class="fas fa-asterisk"></i> {!! $image_error !!}</p>


### PR DESCRIPTION
In order to prevent issue #215 from happening again, this PR covers:

1. Adding the `FilenameLengthRule` validation rule for image uploads to the `HasImageUploads` trait, used to validate `ProfileImageRequest`, `BannerImageRequest`, `ProfileUpdateRequest` for the profiles sections that contain image uploads.
2. Adding tooltips to the sections mentioned above to display the image upload requirements.