### PR TITLE
Upgrade Livewire 2 → 3

### DIFF
--- a/app/Conversions/Svg.php
+++ b/app/Conversions/Svg.php
@@ -13,7 +13,7 @@ class Svg extends ImageGenerator
     /**
      * Converts SVG to PNG, preserving transparency
      */
-    public function convert(string $file, Conversion $conversion = null): string
+    public function convert(string $file, ?Conversion $conversion = null): string
     {
         $imageFile = pathinfo($file, PATHINFO_DIRNAME) . '/' . pathinfo($file, PATHINFO_FILENAME) . '.png';
 
@@ -29,7 +29,7 @@ class Svg extends ImageGenerator
 
     public function requirementsAreInstalled(): bool
     {
-        return class_exists(\Imagick::class);
+        return class_exists(Imagick::class);
     }
 
     public function supportedExtensions(): Collection

--- a/app/Helpers/LdapHelper.php
+++ b/app/Helpers/LdapHelper.php
@@ -113,7 +113,6 @@ class LdapHelper implements LdapHelperContract
     /**
      * Look up and return a local user instance by checking LDAP for that user.
      *
-     * @param  string $display_name The user's display name
      * @param  string $name         The user's name/uid
      *
      * @return User|boolean

--- a/app/Http/Controllers/AppController.php
+++ b/app/Http/Controllers/AppController.php
@@ -2,16 +2,15 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-use Illuminate\Contracts\View\View as ViewContract;
-use Illuminate\View\View;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
 
 class AppController extends Controller
 {
     /**
      * Display the App Homepage.
      */
-    public function index(): View|ViewContract
+    public function index(): View|ViewFactory
     {
         return view('home');
     }
@@ -19,7 +18,7 @@ class AppController extends Controller
     /**
      * Display the FAQ page.
      */
-    public function faq(): View|ViewContract
+    public function faq(): View|ViewFactory
     {
         return view('faq');
     }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
-use Illuminate\Contracts\View\View as ViewContract;
-use Illuminate\View\View;
+use Illuminate\Contracts\View\View;
+use Illuminate\Contracts\View\Factory as ViewFactory;
 
 class LoginController extends Controller
 {
@@ -52,7 +52,7 @@ class LoginController extends Controller
     /**
      * Show the login form.
      */
-    public function showLoginForm(): View|ViewContract
+    public function showLoginForm(): View|ViewFactory
     {
         if (!session()->has('url.intended')) {
             session(['url.intended' => url()->previous()]);

--- a/app/Http/Controllers/LogsController.php
+++ b/app/Http/Controllers/LogsController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers;
 
 use App\LogEntry;
 use Illuminate\Http\Request;
-use Illuminate\Contracts\View\View as ViewContract;
-use Illuminate\View\View;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
 
 class LogsController extends Controller
 {
@@ -22,7 +22,7 @@ class LogsController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index(Request $request): View|ViewContract
+    public function index(Request $request): View|ViewFactory
     {
         return view('logs.index', [
             'logs' => LogEntry::with('user')

--- a/app/Http/Controllers/ProfileStudentsController.php
+++ b/app/Http/Controllers/ProfileStudentsController.php
@@ -3,9 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Profile;
-use Illuminate\Contracts\View\View as ViewContract;
-use Illuminate\Http\Request;
-use Illuminate\View\View;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
 
 class ProfileStudentsController extends Controller
 {
@@ -22,7 +21,7 @@ class ProfileStudentsController extends Controller
     /**
      * Show student applications associated with a profile.
      */
-    public function show(Profile $profile): View|ViewContract
+    public function show(Profile $profile): View|ViewFactory
     {
         return view('students.profile-students', [
             'profile' => $profile,

--- a/app/Http/Controllers/ProfilesController.php
+++ b/app/Http/Controllers/ProfilesController.php
@@ -14,14 +14,14 @@ use App\Http\Requests\ProfileImageRequest;
 use App\Http\Requests\ProfileSearchRequest;
 use App\Http\Requests\ProfileUpdateRequest;
 use App\School;
-use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
-use Illuminate\View\View;
 use Spatie\Browsershot\Browsershot;
 
 class ProfilesController extends Controller
@@ -68,7 +68,7 @@ class ProfilesController extends Controller
     /**
      * Display a listing of profiles.
      */
-    public function index(ProfileSearchRequest $request): View|ViewContract|RedirectResponse
+    public function index(ProfileSearchRequest $request): View|ViewFactory|RedirectResponse
     {
         $input_search = $request->input('search');
 
@@ -102,7 +102,7 @@ class ProfilesController extends Controller
     /**
      * Display the home page
      */
-    public function home(): View|ViewContract
+    public function home(): View|ViewFactory
     {
         $random_profile = Cache::tags(['home', 'profiles'])->remember('home-random-profiles', 86400, function() {
             return Profile::public()->excludingUnlisted()->inRandomOrder()->limit(2)->get();
@@ -132,7 +132,7 @@ class ProfilesController extends Controller
     /**
      * Display an admin table of profiles.
      */
-    public function table(): View|ViewContract
+    public function table(): View|ViewFactory
     {
         return view('profiles.table');
     }
@@ -140,7 +140,7 @@ class ProfilesController extends Controller
     /**
      * Show the specified profile.
      */
-    public function show(Request $request, Profile $profile): View|ViewContract
+    public function show(Request $request, Profile $profile): View|ViewFactory
     {
         /** @var User the logged-in user */
         $user = Auth::user();
@@ -172,7 +172,7 @@ class ProfilesController extends Controller
     /**
      * Create a Profile
      */
-    public function create(Request $request, User $user, LdapHelperContract $ldap): View|ViewContract|RedirectResponse
+    public function create(Request $request, User $user, LdapHelperContract $ldap): View|ViewFactory|RedirectResponse
     {
         $existing_profile = $user->profiles()->withTrashed()->first();
 
@@ -233,7 +233,7 @@ class ProfilesController extends Controller
     /**
      * Show the view for editing a profile section
      */
-    public function edit(Profile $profile, string $section): View|ViewContract|RedirectResponse
+    public function edit(Profile $profile, string $section): View|ViewFactory|RedirectResponse
     {
         //dont manage auto-managed publications
         if ($section == 'publications' && $profile->hasOrcidManagedPublications()) {
@@ -294,7 +294,7 @@ class ProfilesController extends Controller
     /**
      * Confirm deletion of a profile
      */
-    public function confirmDelete(Profile $profile): View|ViewContract
+    public function confirmDelete(Profile $profile): View|ViewFactory
     {
         return view('profiles.delete', ['profile' => $profile]);
     }
@@ -302,7 +302,7 @@ class ProfilesController extends Controller
     /**
      * Confirm restoration of a soft-deleted profile
      */
-    public function confirmRestore(Request $request, Profile $profile): View|ViewContract|RedirectResponse
+    public function confirmRestore(Request $request, Profile $profile): View|ViewFactory|RedirectResponse
     {
         // this message is in case someone tries to create an already archived profile
         if ($request->user()->cannot('restore', $profile)) {

--- a/app/Http/Controllers/SchoolsController.php
+++ b/app/Http/Controllers/SchoolsController.php
@@ -4,10 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Profile;
 use App\School;
-use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\View\View;
 
 class SchoolsController extends Controller
 {
@@ -35,7 +35,7 @@ class SchoolsController extends Controller
     /**
      * Display a list of schools.
      */
-    public function index(): View|ViewContract
+    public function index(): View|ViewFactory
     {
         $schools = School::get();
 
@@ -45,7 +45,7 @@ class SchoolsController extends Controller
     /**
      * Show the form for creating a new school.
      */
-    public function create(): View|ViewContract
+    public function create(): View|ViewFactory
     {
         return view('schools.create');
     }
@@ -65,7 +65,7 @@ class SchoolsController extends Controller
     /**
      * Display all profiles from the specified school.
      */
-    public function show(School $school): View|ViewContract
+    public function show(School $school): View|ViewFactory
     {
         $profiles = Profile::fromSchoolId($school->id)->public()->excludingUnlisted()->paginate(24);
 
@@ -75,7 +75,7 @@ class SchoolsController extends Controller
     /**
      * Show the form for editing the specified school.
      */
-    public function edit(School $school): View|ViewContract
+    public function edit(School $school): View|ViewFactory
     {
         return view('schools.edit', compact('school'));
     }

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -3,10 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Setting;
-use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\View\View;
 use Illuminate\Support\Facades\Cache;
 
 class SettingsController extends Controller
@@ -23,7 +23,7 @@ class SettingsController extends Controller
     /**
      * Show the settings for editing.
      */
-    public function edit(): View|ViewContract
+    public function edit(): View|ViewFactory
     {
         return view('settings', [
             'settings' => Setting::pluck('value', 'name')->toArray(),

--- a/app/Http/Controllers/StudentsController.php
+++ b/app/Http/Controllers/StudentsController.php
@@ -7,12 +7,11 @@ use App\Http\Requests\StudentUpdateRequest;
 use App\Student;
 use App\StudentData;
 use App\User;
-use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\View\View;
 
 class StudentsController extends Controller
 {
@@ -35,7 +34,7 @@ class StudentsController extends Controller
     /**
      * Display the list of student research applications.
      */
-    public function index(): View|ViewContract
+    public function index(): View|ViewFactory
     {
         /** @var User */
         $user = Auth::user();
@@ -94,7 +93,7 @@ class StudentsController extends Controller
     /**
      * Display the specified student research application.
      */
-    public function show(Request $request, Student $student): View|ViewContract
+    public function show(Request $request, Student $student): View|ViewFactory
     {
         if ($request->user() && $request->user()->userOrDelegatorhasRole('faculty')) {
             StudentViewed::dispatch($student);
@@ -114,7 +113,7 @@ class StudentsController extends Controller
     /**
      * Show the form for editing the specified student research application.
      */
-    public function edit(Student $student): View|ViewContract
+    public function edit(Student $student): View|ViewFactory
     {
         return view('students.edit', [
             'student' => $student,

--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\View\View;
 use Spatie\Tags\Tag;
 use App\Http\Requests\TagsUpdateRequest;
 use App\Http\Requests\TagUpdateRequest;
@@ -39,7 +39,7 @@ class TagsController extends Controller
     /**
      * Show the index of all associated tags.
      */
-    public function index(): View|ViewContract
+    public function index(): View|ViewFactory
     {
         $tags = Tag::whereExists(function($query) {
             $query->select(\DB::raw(1))->from('taggables')->whereRaw('tags.id = taggables.tag_id');
@@ -57,7 +57,7 @@ class TagsController extends Controller
     /**
      * Show the index table of all associated tags.
      */
-    public function table(): View|ViewContract
+    public function table(): View|ViewFactory
     {
         return view('tags.table');
     }
@@ -65,7 +65,7 @@ class TagsController extends Controller
     /**
      * Show the index table of all associated tags.
      */
-    public function create(): View|ViewContract
+    public function create(): View|ViewFactory
     {
         return view('tags.create');
     }

--- a/app/Http/Controllers/Testing/TestingController.php
+++ b/app/Http/Controllers/Testing/TestingController.php
@@ -8,11 +8,13 @@ use App\User;
 use App\Http\Controllers\Controller;
 use App\Profile;
 use Exception;
-use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Contracts\Routing\ResponseFactory;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\View\View;
+use Illuminate\Support\Facades\Auth;
 
 class TestingController extends Controller
 {
@@ -49,7 +51,7 @@ class TestingController extends Controller
     /**
      * Show a list of possible users to login as
      */
-    public function showLoginAsList(): Response
+    public function showLoginAsList(): Response|ResponseFactory
     {
         $output = "<h1>Log in as a Different User</h1>\n";
         $output .= "<ul>\n";
@@ -67,7 +69,7 @@ class TestingController extends Controller
      */
     public function loginAs(int $id): RedirectResponse
     {
-        auth()->loginUsingId($id);
+        Auth::loginUsingId($id);
 
         return redirect()->route('profiles.home');
     }
@@ -75,7 +77,7 @@ class TestingController extends Controller
     /**
      * Preview an email template
      */
-    public function previewEmail(Request $request, string $view): View|ViewContract
+    public function previewEmail(Request $request, string $view): View|ViewFactory
     {
         $default_params = [];
 

--- a/app/Http/Controllers/UserDelegationsController.php
+++ b/app/Http/Controllers/UserDelegationsController.php
@@ -3,9 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\User;
-use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
-use Illuminate\View\View;
 
 class UserDelegationsController extends Controller
 {
@@ -24,7 +24,7 @@ class UserDelegationsController extends Controller
     /**
      * Display a listing of all delegations.
      */
-    public function index(): View|ViewContract
+    public function index(): View|ViewFactory
     {
         return view('users.delegations.index');
     }
@@ -32,7 +32,7 @@ class UserDelegationsController extends Controller
     /**
      * Display the specified user's delegations.
      */
-    public function show(User $user): View|ViewContract
+    public function show(User $user): View|ViewFactory
     {
         return view('users.delegations.show', [
             'user' => $user,

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -9,12 +9,12 @@ use App\Role;
 use App\School;
 use App\Student;
 use App\User;
-use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\View\View;
 
 class UsersController extends Controller
 {
@@ -58,7 +58,7 @@ class UsersController extends Controller
     /**
      * Display a listing of Users.
      */
-    public function index(): View|ViewContract
+    public function index(): View|ViewFactory
     {
         return view('users.index');
     }
@@ -66,7 +66,7 @@ class UsersController extends Controller
     /**
      * Show the specified User's info.
      */
-    public function show(User $user): View|ViewContract
+    public function show(User $user): View|ViewFactory
     {
         return view('users.show', [
             'user' => $user,
@@ -79,7 +79,7 @@ class UsersController extends Controller
     /**
      * Show the specified User's bookmarks.
      */
-    public function showBookmarks(User $user): View|ViewContract
+    public function showBookmarks(User $user): View|ViewFactory
     {
         return view('users.bookmarks', [
             'user' => $user,
@@ -91,7 +91,7 @@ class UsersController extends Controller
     /**
      * Show the view to add a new user
      */
-    public function create(): View|ViewContract
+    public function create(): View|ViewFactory
     {
         return view('users.create');
     }
@@ -118,7 +118,7 @@ class UsersController extends Controller
     /**
      * Show the view to edit the specified User
      */
-    public function edit(User $user): View|ViewContract
+    public function edit(User $user): View|ViewFactory
     {
         $roles = Role::all();
         $school_editor_role = $roles->firstWhere('name', 'school_profiles_editor');
@@ -160,7 +160,7 @@ class UsersController extends Controller
     /**
      * Confirm deletion of the specified user
      */
-    public function confirmDelete(User $user): View|ViewContract|RedirectResponse
+    public function confirmDelete(User $user): View|ViewFactory|RedirectResponse
     {
         /** @var User */
         $logged_in_user = Auth::user();

--- a/app/Http/Livewire/AcceptingStudentsToggle.php
+++ b/app/Http/Livewire/AcceptingStudentsToggle.php
@@ -33,10 +33,10 @@ class AcceptingStudentsToggle extends Component
         ]);
 
         if (!$updated) {
-            $this->emit('alert', "Not saved. There was a problem changing that setting", 'danger');
+            $this->dispatch('alert', message: "Not saved. There was a problem changing that setting", type: 'danger');
         }
 
-        $this->emit('alert', "<strong>Saved.</strong><br> Profile for {$this->profile->full_name} marked as " . ($toggled_on ? "not" : "") . " accepting undergraduate students", 'success');
+        $this->dispatch('alert', message: "<strong>Saved.</strong><br> Profile for {$this->profile->full_name} marked as " . ($toggled_on ? "not" : "") . " accepting undergraduate students", type: 'success');
     }
 
     public function render()

--- a/app/Http/Livewire/BookmarkButton.php
+++ b/app/Http/Livewire/BookmarkButton.php
@@ -33,7 +33,7 @@ class BookmarkButton extends Component
 
         $this->user->bookmark($this->model);
 
-        $this->emit('alert', "Bookmarked!", 'success');
+        $this->dispatch('alert', message: 'Bookmarked!', type: 'success');
     }
 
     public function unbookmark()
@@ -42,6 +42,6 @@ class BookmarkButton extends Component
 
         $this->user->unbookmark($this->model);
 
-        $this->emit('alert', "Removed from your bookmarks", 'success');
+        $this->dispatch('alert', message: 'Removed from your bookmarks', type: 'success');
     }
 }

--- a/app/Http/Livewire/Concerns/HasFilters.php
+++ b/app/Http/Livewire/Concerns/HasFilters.php
@@ -7,7 +7,7 @@ trait HasFilters
     public function resetFilters()
     {
         $this->reset($this->availableFilters());
-        $this->emit('alert', "Cleared all filters.", 'success');
+        $this->dispatch('alert', message: "Cleared all filters.", type: 'success');
     }
 
     public function resetFilter($filter_name)
@@ -19,7 +19,7 @@ trait HasFilters
     protected function emitFilterUpdatedEvent($name, $value)
     {
         if ($this->isAFilter($name)) {
-            $this->emit('alert', ($value === '') ? "Cleared filter." : "Applied filter.", 'success');
+            $this->dispatch('alert', message: ($value === '') ? "Cleared filter." : "Applied filter.", type: 'success');
         }
     }
 

--- a/app/Http/Livewire/DelegationsTable.php
+++ b/app/Http/Livewire/DelegationsTable.php
@@ -7,6 +7,7 @@ use App\Http\Livewire\Concerns\HasPagination;
 use App\Http\Livewire\Concerns\HasSorting;
 use App\UserDelegation;
 use Illuminate\Support\Str;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
 
 class DelegationsTable extends Component
@@ -33,7 +34,8 @@ class DelegationsTable extends Component
         $this->sort_descending = true;
     }
 
-    public function getDelegationsProperty()
+    #[Computed()]
+    public function delegations()
     {
         return UserDelegation::query()
             ->search($this->search_filter, $this->search_fields)

--- a/app/Http/Livewire/DirectorySearch.php
+++ b/app/Http/Livewire/DirectorySearch.php
@@ -4,6 +4,7 @@ namespace App\Http\Livewire;
 
 use App\Helpers\Contracts\LdapHelperContract;
 use Livewire\Component;
+use Livewire\Attributes\On;
 
 class DirectorySearch extends Component
 {
@@ -27,10 +28,6 @@ class DirectorySearch extends Component
 
     public $title_attribute = 'title';
 
-    protected $listeners = [
-        'profiles.directorySearch.reset' => 'resetAll',
-    ];
-
     protected $ldap;
 
     protected $limit = 15;
@@ -50,6 +47,7 @@ class DirectorySearch extends Component
         $this->ldap = $ldap;
     }
 
+    #[On('profiles.directorySearch.reset')] 
     public function resetAll()
     {
         $this->reset(['query', 'people', 'selected_username']);

--- a/app/Http/Livewire/DirectorySearch.php
+++ b/app/Http/Livewire/DirectorySearch.php
@@ -63,7 +63,7 @@ class DirectorySearch extends Component
     public function resetSelected()
     {
         $this->reset(['selected_username']);
-        $this->emit('profiles.directorySearch.selected', '');
+        $this->dispatch('profiles.directorySearch.selected', username: '');
     }
 
     public function selectPerson($index)
@@ -71,7 +71,7 @@ class DirectorySearch extends Component
         $this->query = $this->people[$index][$this->displayname_attribute] ?? $this->query;
         $this->selected_username = $this->people[$index][$this->username_attribute] ?? '';
 
-        $this->emit('profiles.directorySearch.selected', $this->selected_username);
+        $this->dispatch('profiles.directorySearch.selected', username: $this->selected_username);
     }
 
     public function updatedQuery()
@@ -90,7 +90,7 @@ class DirectorySearch extends Component
 
         $this->people = array_slice($search_results, 0, $this->limit);
 
-        $this->emit('profiles.directorySearch.query.updated');
+        $this->dispatch('profiles.directorySearch.query.updated');
     }
 
     public function render()

--- a/app/Http/Livewire/ProfileDataCard.php
+++ b/app/Http/Livewire/ProfileDataCard.php
@@ -63,10 +63,6 @@ class ProfileDataCard extends Component
     {
         $data = $this->data();
 
-        if ($data->isEmpty() && !$this->editable) {
-            return '';
-        }
-
         return view("livewire.profile-data-cards/{$this->data_type}", [
             'data' => $data,
             'editable' => $this->editable,

--- a/app/Http/Livewire/ProfileStudents.php
+++ b/app/Http/Livewire/ProfileStudents.php
@@ -9,6 +9,7 @@ use App\Student;
 use App\StudentData;
 use Livewire\Component;
 use Spatie\Tags\Tag;
+use Livewire\Attributes\On;
 
 class ProfileStudents extends Component
 {
@@ -37,10 +38,6 @@ class ProfileStudents extends Component
     public $travel_other_filter = '';
 
     public $tag_filter = '';
-
-    protected $listeners = [
-        'profileStudentStatusUpdated' => 'refreshStudents'
-    ];
 
     protected $queryString = [
         'animals_filter' => ['except' => '', 'as' => 'animals'],
@@ -80,6 +77,7 @@ class ProfileStudents extends Component
         $this->emitFilterUpdatedEvent($name, $value);
     }
 
+    #[On('profileStudentStatusUpdated')]
     public function refreshStudents()
     {
         unset($this->students);

--- a/app/Http/Livewire/ProfileStudents.php
+++ b/app/Http/Livewire/ProfileStudents.php
@@ -7,6 +7,7 @@ use App\Http\Livewire\Concerns\HasFilters;
 use App\ProfileStudent;
 use App\Student;
 use App\StudentData;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
 use Spatie\Tags\Tag;
 use Livewire\Attributes\On;
@@ -53,7 +54,8 @@ class ProfileStudents extends Component
         'semester_filter' => ['except' => '', 'as' => 'semester'],
     ];
 
-    public function getStudentsProperty()
+    #[Computed]
+    public function students()
     {
         return $this->profile->students()
             ->submitted()

--- a/app/Http/Livewire/ProfilesTable.php
+++ b/app/Http/Livewire/ProfilesTable.php
@@ -7,6 +7,7 @@ use App\Http\Livewire\Concerns\HasPagination;
 use App\Http\Livewire\Concerns\HasSorting;
 use App\Profile;
 use App\School;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
 
 class ProfilesTable extends Component
@@ -39,7 +40,8 @@ class ProfilesTable extends Component
         $this->sort_descending = false;
     }
 
-    public function getProfilesProperty()
+    #[Computed()]
+    public function profiles()
     {
         return Profile::query()
             ->with(['user.school', 'user.setting'])

--- a/app/Http/Livewire/StudentFeedback.php
+++ b/app/Http/Livewire/StudentFeedback.php
@@ -4,6 +4,7 @@ namespace App\Http\Livewire;
 
 use App\StudentFeedback as StudentFeedbackEntry;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
 
 class StudentFeedback extends Component
@@ -14,7 +15,8 @@ class StudentFeedback extends Component
 
     public $new_feedback = [];
 
-    public function getFeedbackProperty()
+    #[Computed()]
+    public function feedback()
     {
         return $this->student
             ->feedback()

--- a/app/Http/Livewire/StudentFeedback.php
+++ b/app/Http/Livewire/StudentFeedback.php
@@ -31,10 +31,10 @@ class StudentFeedback extends Component
         ]);
 
         if ($feedback) {
-            $this->emit('alert', "Feedback saved. Thank you!", 'success');
+            $this->dispatch('alert', "Feedback saved. Thank you!", 'success');
             $this->new_feedback = [];
         } else {
-            $this->emit('alert', "Unable to save feedback", 'danger');
+            $this->dispatch('alert', message: "Unable to save feedback", type: 'danger');
         }
     }
 
@@ -44,7 +44,7 @@ class StudentFeedback extends Component
 
         $feedback->delete();
 
-        $this->emit('alert', "Feedback removed.", 'success');
+        $this->dispatch('alert', message: "Feedback removed.", type: 'success');
     }
 
     public function render()

--- a/app/Http/Livewire/StudentFiler.php
+++ b/app/Http/Livewire/StudentFiler.php
@@ -34,10 +34,10 @@ class StudentFiler extends Component
                 $this->student->updateAcceptedStats($this->profile, false);
             }
             $this->status = $new_status;
-            $this->emit('alert', "{$this->student->full_name} filed as {$new_status_name}", 'success');
-            $this->emit('profileStudentStatusUpdated');
+            $this->dispatch('alert', message: "{$this->student->full_name} filed as {$new_status_name}",  type: 'success');
+            $this->dispatch('profileStudentStatusUpdated');
         } else {
-            $this->emit('alert', "Unable to file student.", 'danger');
+            $this->dispatch('alert', message: "Unable to file student.", type: 'danger');
         }
     }
 

--- a/app/Http/Livewire/StudentsTable.php
+++ b/app/Http/Livewire/StudentsTable.php
@@ -9,6 +9,7 @@ use App\Http\Livewire\Concerns\HasFilters;
 use App\Http\Livewire\Concerns\HasPagination;
 use App\Http\Livewire\Concerns\HasSorting;
 use App\Profile;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
 use Spatie\Tags\Tag;
 
@@ -49,7 +50,8 @@ class StudentsTable extends Component
         $this->status_filter = 'submitted';
     }
 
-    public function getStudentsProperty()
+    #[Computed]
+    public function students()
     {
         return Student::query()
             ->with(['research_profile', 'tags', 'faculty'])

--- a/app/Http/Livewire/TagsModal.php
+++ b/app/Http/Livewire/TagsModal.php
@@ -4,6 +4,7 @@ namespace App\Http\Livewire;
 
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Str;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
 use Spatie\Tags\Tag;
 use Livewire\Attributes\On;
@@ -69,7 +70,8 @@ class TagsModal extends Component
      *
      * @return EloquentCollection
      */
-    public function getPossibleTagsProperty()
+    #[Computed]
+    public function possibleTags()
     {
         /** @var EloquentCollection */
         $tags = Tag::whereIn('type', $this->tags_type)

--- a/app/Http/Livewire/TagsModal.php
+++ b/app/Http/Livewire/TagsModal.php
@@ -6,13 +6,12 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Str;
 use Livewire\Component;
 use Spatie\Tags\Tag;
+use Livewire\Attributes\On;
 
 class TagsModal extends Component
 {
     /** @var \Illuminate\Database\Eloquent\Model */
     public $model;
-
-    protected $listeners = ['addTagType', 'removeTagType'];
 
     public $model_slug;
 
@@ -46,6 +45,7 @@ class TagsModal extends Component
         $this->tags = $this->selected_tags->sortBy('name', SORT_NATURAL | SORT_FLAG_CASE);
     }
 
+    #[On('addTagType')]
     public function addTagType($tag_type)
     {
         if (!in_array($tag_type, $this->tags_type)) {
@@ -53,6 +53,7 @@ class TagsModal extends Component
         }
     }
 
+    #[On('removeTagType')]
     public function removeTagType($tag_type)
     {
         if (($key = array_search($tag_type, $this->tags_type)) !== false) {

--- a/app/Http/Livewire/TagsTable.php
+++ b/app/Http/Livewire/TagsTable.php
@@ -6,6 +6,7 @@ use App\Http\Livewire\Concerns\HasFilters;
 use App\Http\Livewire\Concerns\HasPagination;
 use App\Http\Livewire\Concerns\HasSorting;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
 use Spatie\Tags\Tag;
 
@@ -25,7 +26,8 @@ class TagsTable extends Component
         $this->per_page = 10;
     }
 
-    public function getTagsProperty()
+    #[Computed]
+    public function tags()
     {
         return Tag::query()
             ->when($this->tag_type_filter, function ($q) {

--- a/app/Http/Livewire/TagsTable.php
+++ b/app/Http/Livewire/TagsTable.php
@@ -56,7 +56,7 @@ class TagsTable extends Component
 
         $tag->delete();
 
-        $this->emit('alert', "Deleted tag $tag_name", 'success');
+        $this->dispatch('alert', message: "Deleted tag $tag_name", type: 'success');
     }
 
     public function render()

--- a/app/Http/Livewire/UserDelegations.php
+++ b/app/Http/Livewire/UserDelegations.php
@@ -6,9 +6,9 @@ use App\Helpers\Contracts\LdapHelperContract;
 use App\Http\Livewire\Concerns\ConvertEmptyStringsToNull;
 use App\User;
 use App\UserDelegation;
-use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use Illuminate\View\View;
 use Livewire\Component;
 
 class UserDelegations extends Component
@@ -89,7 +89,7 @@ class UserDelegations extends Component
         $this->emit('alert', "Removed delegation", 'success');
     }
 
-    public function render(): View|ViewContract
+    public function render(): View|ViewFactory
     {
         return view('livewire.user-delegations', [
             'delegations' => $this->user->delegations()->with('delegate')->get(),

--- a/app/Http/Livewire/UserDelegations.php
+++ b/app/Http/Livewire/UserDelegations.php
@@ -72,11 +72,11 @@ class UserDelegations extends Component
                 'gets_reminders' => $this->new_delegation['gets_reminders'] ?? false,
             ]);
 
-            $this->emit('alert', "Delegate saved.", 'success');
-            $this->emit('profiles.directorySearch.reset');
+            $this->dispatch('alert', message: "Delegate saved.",  type: 'success');
+            $this->dispatch('profiles.directorySearch.reset');
             $this->resetNewDelegation();
         } else {
-            $this->emit('alert', "Unable to save delegate", 'danger');
+            $this->dispatch('alert', message: "Unable to save delegate", type: 'danger');
         }
     }
 
@@ -86,7 +86,7 @@ class UserDelegations extends Component
 
         $delegation->delete();
 
-        $this->emit('alert', "Removed delegation", 'success');
+        $this->dispatch('alert', message: "Removed delegation", type: 'success');
     }
 
     public function render(): View|ViewFactory

--- a/app/Http/Livewire/UserDelegations.php
+++ b/app/Http/Livewire/UserDelegations.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Component;
+use Livewire\Attributes\On;
 
 class UserDelegations extends Component
 {
@@ -36,10 +37,6 @@ class UserDelegations extends Component
         'new_delegation.gets_reminders.boolean' => 'The gets reminders field must be true/false.',
     ];
 
-    protected $listeners = [
-        'profiles.directorySearch.selected' => 'selectPerson',
-    ];
-
     public function mount(User $user): void
     {
         $this->user = $user;
@@ -53,6 +50,7 @@ class UserDelegations extends Component
         ];
     }
 
+    #[On('profiles.directorySearch.selected')]
     public function selectPerson(string $username): void
     {
         $this->new_delegation['name'] = $username;

--- a/app/Http/Livewire/UsersTable.php
+++ b/app/Http/Livewire/UsersTable.php
@@ -7,6 +7,7 @@ use App\Http\Livewire\Concerns\HasPagination;
 use App\Http\Livewire\Concerns\HasSorting;
 use App\School;
 use App\User;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
 
 class UsersTable extends Component
@@ -38,7 +39,8 @@ class UsersTable extends Component
         $this->sort_descending = false;
     }
 
-    public function getUsersProperty()
+    #[Computed]
+    public function users()
     {
         return User::query()
             ->with(['school', 'profiles', 'setting'])

--- a/app/Ldap/Handlers/LdapAttributeHandler.php
+++ b/app/Ldap/Handlers/LdapAttributeHandler.php
@@ -12,7 +12,7 @@ class LdapAttributeHandler
     /**
      * Sync things from an Ldap User to a local User.
      *
-     * @param LdapUser  $ldapUser
+     * @param LdapUser  $ldap_user
      * @param User      $user
      */
     public function handle(LdapUser $ldap_user, User $user)

--- a/app/Policies/SettingPolicy.php
+++ b/app/Policies/SettingPolicy.php
@@ -13,7 +13,7 @@ class SettingPolicy
     /**
      * Runs before any other authorization checks
      *
-     * @param \App\User $user
+     * @param User $user
      * @param string $ability
      * @return void|bool
      */
@@ -27,7 +27,7 @@ class SettingPolicy
     /**
      * Determine whether the user can view the index.
      *
-     * @param  \App\User  $user
+     * @param  User  $user
      * @return mixed
      */
     public function viewAny(User $user)
@@ -38,11 +38,11 @@ class SettingPolicy
     /**
      * Determine whether the user can view the setting.
      *
-     * @param  \App\User  $user
-     * @param  \App\Setting  $setting
+     * @param  User  $user
+     * @param  Setting|null  $setting
      * @return mixed
      */
-    public function view(User $user)
+    public function view(User $user, ?Setting $setting = null)
     {
         return false;
     }
@@ -50,7 +50,7 @@ class SettingPolicy
     /**
      * Determine whether the user can create settings.
      *
-     * @param  \App\User  $user
+     * @param  User  $user
      * @return mixed
      */
     public function create(User $user)
@@ -61,11 +61,11 @@ class SettingPolicy
     /**
      * Determine whether the user can update the setting.
      *
-     * @param  \App\User  $user
-     * @param  \App\Setting  $setting
+     * @param  User  $user
+     * @param  Setting|null  $setting
      * @return mixed
      */
-    public function update(User $user)
+    public function update(User $user, ?Setting $setting = null)
     {
         return false;
     }
@@ -73,11 +73,11 @@ class SettingPolicy
     /**
      * Determine whether the user can delete the setting.
      *
-     * @param  \App\User  $user
-     * @param  \App\Setting  $setting
+     * @param  User  $user
+     * @param  Setting|null  $setting
      * @return mixed
      */
-    public function delete(User $user)
+    public function delete(User $user, ?Setting $setting = null)
     {
         return false;
     }

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -13,7 +13,7 @@ class TagPolicy
     /**
      * Runs before any other authorization checks
      *
-     * @param \App\User $user
+     * @param User $user
      * @param string $ability
      * @return void|bool
      */
@@ -27,7 +27,7 @@ class TagPolicy
     /**
      * Determine whether the user can view the model.
      *
-     * @param  \App\User  $user
+     * @param  User  $user
      * @return mixed
      */
     public function viewAdminIndex(User $user)
@@ -38,7 +38,7 @@ class TagPolicy
     /**
      * Determine whether the user can create tags.
      *
-     * @param  \App\User  $user
+     * @param  User  $user
      * @return mixed
      */
     public function create(User $user)
@@ -49,11 +49,11 @@ class TagPolicy
     /**
      * Determine whether the user can update the tag.
      *
-     * @param  \App\User  $user
-     * @param  \Spatie\Tags\Tag  $tag
+     * @param  User  $user
+     * @param  Tag|null  $tag
      * @return mixed
      */
-    public function update(User $user)
+    public function update(User $user, ?Tag $tag = null)
     {
         return false;
     }
@@ -61,11 +61,11 @@ class TagPolicy
     /**
      * Determine whether the user can update the tag.
      *
-     * @param  \App\User  $user
-     * @param  \Spatie\Tags\Tag  $tag
+     * @param  User  $user
+     * @param  Tag  $tag
      * @return mixed
      */
-    public function updateTag(User $user)
+    public function updateTag(User $user, ?Tag $tag = null)
     {
         return false;
     }
@@ -73,11 +73,11 @@ class TagPolicy
     /**
      * Determine whether the user can delete the tag.
      *
-     * @param  \App\User  $user
-     * @param  \Spatie\Tags\Tag  $tag
+     * @param  User  $user
+     * @param  Tag  $tag
      * @return mixed
      */
-    public function delete(User $user)
+    public function delete(User $user, ?Tag $tag = null)
     {
         return false;
     }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -62,7 +62,7 @@ class UserPolicy
      * Determine whether the user can view the delegator's delegations.
      *
      * @param  \App\User  $user
-     * @param  \App\User  $model
+     * @param  \App\User  $delegator
      * @return mixed
      */
     public function viewDelegations(User $user, User $delegator)
@@ -74,7 +74,7 @@ class UserPolicy
      * Determine whether the user can view the owner's bookmarks.
      *
      * @param  \App\User  $user
-     * @param  \App\User  $model
+     * @param  \App\User  $owner
      * @return mixed
      */
     public function viewBookmarks(User $user, User $owner)

--- a/app/Profile.php
+++ b/app/Profile.php
@@ -10,7 +10,7 @@ use App\User;
 use Illuminate\Database\Eloquent\Model;
 use OwenIt\Auditing\Auditable as HasAudits;
 use OwenIt\Auditing\Contracts\Auditable;
-use Spatie\Image\Manipulations;
+use Spatie\Image\Enums\CropPosition;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -351,23 +351,23 @@ class Profile extends Model implements HasMedia, Auditable
      *
      * @param  Media|null $media
      */
-    public function registerMediaConversions(Media $media = null): void
+    public function registerMediaConversions(?Media $media = null): void
     {
-        $this->registerImageThumbnails($media, 'thumb', 150);
-        $this->registerImageThumbnails($media, 'medium', 450);
-        $this->registerImageThumbnails($media, 'large', 1800, 1200, '*');
+        $this->registerImageThumbnails('thumb', 150);
+        $this->registerImageThumbnails('medium', 450);
+        $this->registerImageThumbnails('large', 1800, 1200, '*');
     }
 
     /**
      * Registers image thumbnails.
      *
-     * @param  Media|null $media
      * @param  string     $name       Name of the thumbnail
-     * @param  int        $size       Max dimension in pixels
+     * @param  int        $width      Max width dimension in pixels
+     * @param  int        $height     Max height dimension in pixels
      * @param  string     $collection Name of the collection for the thumbnails
      * @return void
      */
-    protected function registerImageThumbnails(Media $media = null, $name, $width, $height = null, $collection = 'images'): void
+    protected function registerImageThumbnails(string $name, int $width, ?int $height = null, $collection = 'images'): void
     {
         if(!$height) {
             $height = $width;
@@ -376,7 +376,7 @@ class Profile extends Model implements HasMedia, Auditable
         $this->addMediaConversion($name)
             ->width($width)
             ->height($height)
-            ->crop(Manipulations::CROP_TOP, $width, $height)
+            ->crop($width, $height, CropPosition::Top)
             ->performOnCollections($collection);
     }
 

--- a/app/Profile.php
+++ b/app/Profile.php
@@ -16,12 +16,16 @@ use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\Tags\HasTags;
 use GuzzleHttp\Client;
+use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Cache;
 
 /**
+ * @mixin Builder
+ * @mixin QueryBuilder
  * @method public()
  * @method private()
  * @method withApiData(array|string|null $sections)
@@ -37,6 +41,7 @@ class Profile extends Model implements HasMedia, Auditable
 {
     use HasAudits;
     use HasFactory;
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
     use HasTags;
     use SoftDeletes;
@@ -625,7 +630,7 @@ class Profile extends Model implements HasMedia, Auditable
     /**
      * Get the full image URL. ($this->full_image_url)
      *
-     * @return string
+     * @return UrlGenerator|string
      */
     public function getFullImageUrlAttribute()
     {
@@ -635,7 +640,7 @@ class Profile extends Model implements HasMedia, Auditable
     /**
      * Get the full image URL. ($this->large_image_url)
      *
-     * @return string
+     * @return UrlGenerator|string
      */
     public function getLargeImageUrlAttribute()
     {
@@ -645,7 +650,7 @@ class Profile extends Model implements HasMedia, Auditable
     /**
      * Get the image URL. ($this->image_url)
      *
-     * @return string
+     * @return UrlGenerator|string
      */
     public function getImageUrlAttribute()
     {
@@ -655,7 +660,7 @@ class Profile extends Model implements HasMedia, Auditable
     /**
      * Get the image thumbnail URL. ($this->image_thumb_url)
      *
-     * @return string
+     * @return UrlGenerator|string
      */
     public function getImageThumbUrlAttribute()
     {
@@ -665,7 +670,7 @@ class Profile extends Model implements HasMedia, Auditable
     /**
      * Get the banner image thumbnail. ($this->banner_url)
      *
-     * @return string
+     * @return UrlGenerator|string
      */
     public function getBannerUrlAttribute()
     {

--- a/app/ProfileData.php
+++ b/app/ProfileData.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use App\Profile;
+use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -16,6 +17,7 @@ class ProfileData extends Model implements HasMedia, Auditable
 {
     use HasFactory;
     use HasAudits;
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
 
     /** @var string The database table used by the model */
@@ -183,7 +185,7 @@ class ProfileData extends Model implements HasMedia, Auditable
     /**
      * Get the image URL. ($this->image_url)
      *
-     * @return string
+     * @return UrlGenerator|string
      */
     public function getImageUrlAttribute()
     {

--- a/app/ProfileData.php
+++ b/app/ProfileData.php
@@ -55,22 +55,21 @@ class ProfileData extends Model implements HasMedia, Auditable
      *
      * @param  Media|null $media
      */
-    public function registerMediaConversions(Media $media = null): void
+    public function registerMediaConversions(?Media $media = null): void
     {
-        $this->registerImageThumbnails($media, 'thumb', 150);
-        $this->registerImageThumbnails($media, 'medium', 350);
+        $this->registerImageThumbnails('thumb', 150);
+        $this->registerImageThumbnails('medium', 350);
     }
 
     /**
      * Registers image thumbnails.
      *
-     * @param  Media|null $media
      * @param  string     $name       Name of the thumbnail
      * @param  int        $size       Max dimension in pixels
      * @param  string     $collection Name of the collection for the thumbnails
      * @return void
      */
-    protected function registerImageThumbnails(Media $media = null, $name, $size, $collection = 'images'): void
+    protected function registerImageThumbnails($name, $size, $collection = 'images'): void
     {
         $this->addMediaConversion($name)
             ->width($size)

--- a/app/Setting.php
+++ b/app/Setting.php
@@ -3,7 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
-use Spatie\Image\Manipulations;
+use Spatie\Image\Enums\CropPosition;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -33,22 +33,22 @@ class Setting extends Model implements HasMedia
      *
      * @param  Media|null $media
      */
-    public function registerMediaConversions(Media $media = null): void
+    public function registerMediaConversions(?Media $media = null): void
     {
-        $this->registerImageThumbnails($media, 'thumb', 150);
-        $this->registerImageThumbnails($media, 'medium', 450);
-        $this->registerImageThumbnails($media, 'large', 1800, 1200);
+        $this->registerImageThumbnails('thumb', 150);
+        $this->registerImageThumbnails('medium', 450);
+        $this->registerImageThumbnails('large', 1800, 1200);
     }
 
     /**
      * Registers image thumbnails.
      *
-     * @param  Media|null $media
      * @param  string     $name       Name of the thumbnail
-     * @param  int        $size       Max dimension in pixels
+     * @param  int        $width      Max width dimension in pixels
+     * @param  int        $height     Max height dimension in pixels
      * @return void
      */
-    protected function registerImageThumbnails(Media $media = null, $name, $width, $height = null): void
+    protected function registerImageThumbnails(string $name, int $width, ?int $height = null): void
     {
         if (!$height) {
             $height = $width;
@@ -57,8 +57,8 @@ class Setting extends Model implements HasMedia
         $this->addMediaConversion($name)
             ->width($width)
             ->height($height)
-            ->crop(Manipulations::CROP_TOP, $width, $height)
-            ->format(Manipulations::FORMAT_PNG)
+            ->crop($width, $height, CropPosition::Top)
+            ->format('png')
             ->performOnCollections('logo');
     }
 

--- a/app/Setting.php
+++ b/app/Setting.php
@@ -10,6 +10,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class Setting extends Model implements HasMedia
 {
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
 
     /** @var array The attributes that are mass-assignable */

--- a/app/User.php
+++ b/app/User.php
@@ -391,7 +391,7 @@ class User extends Authenticatable implements Auditable
     {
         return $this->belongsToMany('App\User', 'user_delegations', 'delegator_user_id', 'delegate_user_id')
                     ->using(UserDelegation::class)
-                    ->withPivot('starting', 'until', 'gets_reminders')
+                    ->withPivot(['starting', 'until', 'gets_reminders'])
                     ->withTimestamps();
     }
 
@@ -440,7 +440,7 @@ class User extends Authenticatable implements Auditable
     {
         return $this->belongsToMany('App\User', 'user_delegations', 'delegate_user_id', 'delegator_user_id')
                     ->using(UserDelegation::class)
-                    ->withPivot('starting', 'until', 'gets_reminders')
+                    ->withPivot(['starting', 'until', 'gets_reminders'])
                     ->withTimestamps();
     }
 
@@ -472,7 +472,7 @@ class User extends Authenticatable implements Auditable
     /**
      * Additional roles currently delegated to the user.
      *
-     * @return \Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function currentDelegatedRoles()
     {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "laravel/ui": "^4.0",
         "laravelcollective/html": "^6.3.0",
         "league/flysystem-aws-s3-v3": "^3.0",
-        "livewire/livewire": "^2.10",
+        "livewire/livewire": "^3.0",
         "owen-it/laravel-auditing": "^13.0",
         "predis/predis": "^1.1",
         "sentry/sentry-laravel": "^4.15.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "sentry/sentry-laravel": "^4.15.0",
         "spatie/browsershot": "^5.1.0",
         "spatie/laravel-backup": "^8.1",
-        "spatie/laravel-medialibrary": "^10.3.6",
+        "spatie/laravel-medialibrary": "^11.23.1",
         "spatie/laravel-tags": "^4.3.2",
         "stevebauman/purify": "^5.1.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9fdbdc552d45f04ff380c62d5a8f0e53",
+    "content-hash": "8bd61a35b6f0c088c002c0df3b10ec95",
     "packages": [
         {
             "name": "adldap2/adldap2",
@@ -2748,34 +2748,37 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v2.12.8",
+            "version": "v3.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "7d657d0dd8761a981f7ac3cd8d71c3b724f3e0b8"
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/7d657d0dd8761a981f7ac3cd8d71c3b724f3e0b8",
-                "reference": "7d657d0dd8761a981f7ac3cd8d71c3b724f3e0b8",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/e77fce60d0615d68dc6b8fafe98a6739d9752a24",
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24",
                 "shasum": ""
             },
             "require": {
-                "illuminate/database": "^7.0|^8.0|^9.0|^10.0",
-                "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
-                "illuminate/validation": "^7.0|^8.0|^9.0|^10.0",
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.24|^0.2|^0.3",
                 "league/mime-type-detection": "^1.9",
-                "php": "^7.2.5|^8.0",
-                "symfony/http-kernel": "^5.0|^6.0"
+                "php": "^8.1",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-kernel": "^6.2|^7.0|^8.0"
             },
             "require-dev": {
                 "calebporzio/sushi": "^2.1",
-                "laravel/framework": "^7.0|^8.0|^9.0|^10.0",
+                "laravel/framework": "^10.15.0|^11.0|^12.0|^13.0",
                 "mockery/mockery": "^1.3.1",
-                "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0",
-                "orchestra/testbench-dusk": "^5.2|^6.0|^7.0|^8.0",
-                "phpunit/phpunit": "^8.4|^9.0",
-                "psy/psysh": "@stable"
+                "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0",
+                "orchestra/testbench-dusk": "^8.24|^9.1|^10.0|^11.0",
+                "phpunit/phpunit": "^10.4|^11.5|^12.5",
+                "psy/psysh": "^0.11.22|^0.12"
             },
             "type": "library",
             "extra": {
@@ -2809,7 +2812,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v2.12.8"
+                "source": "https://github.com/livewire/livewire/tree/v3.8.2"
             },
             "funding": [
                 {
@@ -2817,7 +2820,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-13T19:58:46+00:00"
+            "time": "2026-06-27T03:14:20+00:00"
         },
         {
             "name": "maennchen/zipstream-php",

--- a/composer.lock
+++ b/composer.lock
@@ -187,16 +187,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.360.0",
+            "version": "3.388.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "a21055795be59f3d7c5ca6e4d52a80930dcf8c20"
+                "reference": "6dd9a0674641ef7d302a50cc8f275eb443182dc9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/a21055795be59f3d7c5ca6e4d52a80930dcf8c20",
-                "reference": "a21055795be59f3d7c5ca6e4d52a80930dcf8c20",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6dd9a0674641ef7d302a50cc8f275eb443182dc9",
+                "reference": "6dd9a0674641ef7d302a50cc8f275eb443182dc9",
                 "shasum": ""
             },
             "require": {
@@ -207,26 +207,25 @@
                 "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/promises": "^2.0",
                 "guzzlehttp/psr7": "^2.4.5",
-                "mtdowling/jmespath.php": "^2.8.0",
+                "mtdowling/jmespath.php": "^2.9.1",
                 "php": ">=8.1",
-                "psr/http-message": "^1.0 || ^2.0"
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
             },
             "require-dev": {
                 "andrewsville/php-token-reflection": "^1.4",
                 "aws/aws-php-sns-message-validator": "~1.0",
                 "behat/behat": "~3.0",
                 "composer/composer": "^2.7.8",
-                "dms/phpunit-arraysubset-asserts": "^0.4.0",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
                 "doctrine/cache": "~1.4",
                 "ext-dom": "*",
                 "ext-openssl": "*",
-                "ext-pcntl": "*",
                 "ext-sockets": "*",
-                "phpunit/phpunit": "^5.6.3 || ^8.5 || ^9.5",
+                "phpunit/phpunit": "^10.0",
                 "psr/cache": "^2.0 || ^3.0",
                 "psr/simple-cache": "^2.0 || ^3.0",
                 "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
-                "symfony/filesystem": "^v6.4.0 || ^v7.1.0",
                 "yoast/phpunit-polyfills": "^2.0"
             },
             "suggest": {
@@ -234,6 +233,7 @@
                 "doctrine/cache": "To use the DoctrineCacheAdapter",
                 "ext-curl": "To send requests using cURL",
                 "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
                 "ext-sockets": "To use client-side monitoring"
             },
             "type": "library",
@@ -260,11 +260,11 @@
             "authors": [
                 {
                     "name": "Amazon Web Services",
-                    "homepage": "http://aws.amazon.com"
+                    "homepage": "https://aws.amazon.com"
                 }
             ],
             "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
-            "homepage": "http://aws.amazon.com/sdkforphp",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
             "keywords": [
                 "amazon",
                 "aws",
@@ -278,9 +278,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.360.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.388.0"
             },
-            "time": "2025-11-17T19:46:19+00:00"
+            "time": "2026-07-07T18:11:48+00:00"
         },
         {
             "name": "brick/math",
@@ -488,16 +488,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.10.3",
+            "version": "3.10.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "65edaca19a752730f290ec2fb89d593cb40afb43"
+                "reference": "95d84866bf3c04b2ddca1df7c049714660959aef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/65edaca19a752730f290ec2fb89d593cb40afb43",
-                "reference": "65edaca19a752730f290ec2fb89d593cb40afb43",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/95d84866bf3c04b2ddca1df7c049714660959aef",
+                "reference": "95d84866bf3c04b2ddca1df7c049714660959aef",
                 "shasum": ""
             },
             "require": {
@@ -518,11 +518,11 @@
                 "jetbrains/phpstorm-stubs": "2023.1",
                 "phpstan/phpstan": "2.1.30",
                 "phpstan/phpstan-strict-rules": "^2",
-                "phpunit/phpunit": "9.6.29",
-                "slevomat/coding-standard": "8.24.0",
-                "squizlabs/php_codesniffer": "4.0.0",
-                "symfony/cache": "^5.4|^6.0|^7.0",
-                "symfony/console": "^4.4|^5.4|^6.0|^7.0"
+                "phpunit/phpunit": "9.6.34",
+                "slevomat/coding-standard": "8.27.1",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "symfony/cache": "^5.4|^6.0|^7.0|^8.0",
+                "symfony/console": "^4.4|^5.4|^6.0|^7.0|^8.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -582,7 +582,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.10.3"
+                "source": "https://github.com/doctrine/dbal/tree/3.10.5"
             },
             "funding": [
                 {
@@ -598,33 +598,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-09T09:05:12+00:00"
+            "time": "2026-02-24T08:03:57+00:00"
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<=7.5 || >=13"
+                "phpunit/phpunit": "<=7.5 || >=14"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12 || ^13",
-                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
@@ -644,22 +644,22 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
-            "time": "2025-04-07T20:06:18+00:00"
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "doctrine/event-manager",
-            "version": "2.0.1",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/event-manager.git",
-                "reference": "b680156fa328f1dfd874fd48c7026c41570b9c6e"
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/b680156fa328f1dfd874fd48c7026c41570b9c6e",
-                "reference": "b680156fa328f1dfd874fd48c7026c41570b9c6e",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/dda33921b198841ca8dbad2eaa5d4d34769d18cf",
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf",
                 "shasum": ""
             },
             "require": {
@@ -669,10 +669,10 @@
                 "doctrine/common": "<2.9"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^12",
-                "phpstan/phpstan": "^1.8.8",
-                "phpunit/phpunit": "^10.5",
-                "vimeo/psalm": "^5.24"
+                "doctrine/coding-standard": "^14",
+                "phpdocumentor/guides-cli": "^1.4",
+                "phpstan/phpstan": "^2.1.32",
+                "phpunit/phpunit": "^10.5.58"
             },
             "type": "library",
             "autoload": {
@@ -721,7 +721,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/event-manager/issues",
-                "source": "https://github.com/doctrine/event-manager/tree/2.0.1"
+                "source": "https://github.com/doctrine/event-manager/tree/2.1.1"
             },
             "funding": [
                 {
@@ -737,7 +737,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-22T20:47:39+00:00"
+            "time": "2026-01-29T07:11:08+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1100,31 +1100,31 @@
         },
         {
             "name": "fruitcake/php-cors",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fruitcake/php-cors.git",
-                "reference": "3d158f36e7875e2f040f37bc0573956240a5a38b"
+                "reference": "38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruitcake/php-cors/zipball/3d158f36e7875e2f040f37bc0573956240a5a38b",
-                "reference": "3d158f36e7875e2f040f37bc0573956240a5a38b",
+                "url": "https://api.github.com/repos/fruitcake/php-cors/zipball/38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379",
+                "reference": "38aaa6c3fd4c157ffe2a4d10aa8b9b16ba8de379",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4|^8.0",
-                "symfony/http-foundation": "^4.4|^5.4|^6|^7"
+                "php": "^8.1",
+                "symfony/http-foundation": "^5.4|^6.4|^7.3|^8"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan": "^2",
                 "phpunit/phpunit": "^9",
-                "squizlabs/php_codesniffer": "^3.5"
+                "squizlabs/php_codesniffer": "^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -1155,7 +1155,7 @@
             ],
             "support": {
                 "issues": "https://github.com/fruitcake/php-cors/issues",
-                "source": "https://github.com/fruitcake/php-cors/tree/v1.3.0"
+                "source": "https://github.com/fruitcake/php-cors/tree/v1.4.0"
             },
             "funding": [
                 {
@@ -1167,28 +1167,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-12T05:21:21+00:00"
+            "time": "2025-12-03T09:33:47+00:00"
         },
         {
             "name": "graham-campbell/result-type",
-            "version": "v1.1.3",
+            "version": "v1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GrahamCampbell/Result-Type.git",
-                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945"
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/3ba905c11371512af9d9bdd27d99b782216b6945",
-                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/e01f4a821471308ba86aa202fed6698b6b695e3b",
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.3"
+                "phpoption/phpoption": "^1.9.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20 || ^10.5.28"
+                "phpunit/phpunit": "^8.5.41 || ^9.6.22 || ^10.5.45 || ^11.5.7"
             },
             "type": "library",
             "autoload": {
@@ -1217,7 +1217,7 @@
             ],
             "support": {
                 "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
-                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.3"
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.4"
             },
             "funding": [
                 {
@@ -1229,29 +1229,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-20T21:45:45+00:00"
+            "time": "2025-12-27T19:43:20+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "bcd989ad36c92d42a3715379af91f2defee5b8dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/bcd989ad36c92d42a3715379af91f2defee5b8dd",
+                "reference": "bcd989ad36c92d42a3715379af91f2defee5b8dd",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.12.3",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -1259,9 +1260,10 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.6",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1339,7 +1341,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.13.2"
             },
             "funding": [
                 {
@@ -1355,28 +1357,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-07-05T19:00:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -1422,7 +1425,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -1438,27 +1441,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -1466,8 +1471,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1538,7 +1544,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
             },
             "funding": [
                 {
@@ -1554,29 +1560,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-06-23T15:21:08+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.5",
+            "version": "v1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
+                "reference": "9c19128923b05a5d7355e5d2318d7808b7e33bbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/9c19128923b05a5d7355e5d2318d7808b7e33bbd",
+                "reference": "9c19128923b05a5d7355e5d2318d7808b7e33bbd",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "uri-template/tests": "1.0.0"
             },
             "type": "library",
@@ -1624,7 +1630,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.8"
             },
             "funding": [
                 {
@@ -1640,7 +1646,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:27:06+00:00"
+            "time": "2026-06-23T13:02:23+00:00"
         },
         {
             "name": "intervention/image",
@@ -1788,16 +1794,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v10.49.1",
+            "version": "10.50.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "f857267b80789327cd3e6b077bcf6df5846cf71b"
+                "reference": "3ff39b7a9b83e633383ec9b019827ed54b6d38bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/f857267b80789327cd3e6b077bcf6df5846cf71b",
-                "reference": "f857267b80789327cd3e6b077bcf6df5846cf71b",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/3ff39b7a9b83e633383ec9b019827ed54b6d38bc",
+                "reference": "3ff39b7a9b83e633383ec9b019827ed54b6d38bc",
                 "shasum": ""
             },
             "require": {
@@ -1992,7 +1998,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-09-30T14:56:54+00:00"
+            "time": "2026-02-15T14:12:07+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -2115,16 +2121,16 @@
         },
         {
             "name": "laravel/tinker",
-            "version": "v2.10.1",
+            "version": "v2.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/tinker.git",
-                "reference": "22177cc71807d38f2810c6204d8f7183d88a57d3"
+                "reference": "c9f80cc835649b5c1842898fb043f8cc098dd741"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/tinker/zipball/22177cc71807d38f2810c6204d8f7183d88a57d3",
-                "reference": "22177cc71807d38f2810c6204d8f7183d88a57d3",
+                "url": "https://api.github.com/repos/laravel/tinker/zipball/c9f80cc835649b5c1842898fb043f8cc098dd741",
+                "reference": "c9f80cc835649b5c1842898fb043f8cc098dd741",
                 "shasum": ""
             },
             "require": {
@@ -2133,7 +2139,7 @@
                 "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
                 "php": "^7.2.5|^8.0",
                 "psy/psysh": "^0.11.1|^0.12.0",
-                "symfony/var-dumper": "^4.3.4|^5.0|^6.0|^7.0"
+                "symfony/var-dumper": "^4.3.4|^5.0|^6.0|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "~1.3.3|^1.4.2",
@@ -2175,35 +2181,35 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/tinker/issues",
-                "source": "https://github.com/laravel/tinker/tree/v2.10.1"
+                "source": "https://github.com/laravel/tinker/tree/v2.11.1"
             },
-            "time": "2025-01-27T14:24:01+00:00"
+            "time": "2026-02-06T14:12:35+00:00"
         },
         {
             "name": "laravel/ui",
-            "version": "v4.6.1",
+            "version": "v4.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/ui.git",
-                "reference": "7d6ffa38d79f19c9b3e70a751a9af845e8f41d88"
+                "reference": "ff27db15416c1ed8ad9848f5692e47595dd5de27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/ui/zipball/7d6ffa38d79f19c9b3e70a751a9af845e8f41d88",
-                "reference": "7d6ffa38d79f19c9b3e70a751a9af845e8f41d88",
+                "url": "https://api.github.com/repos/laravel/ui/zipball/ff27db15416c1ed8ad9848f5692e47595dd5de27",
+                "reference": "ff27db15416c1ed8ad9848f5692e47595dd5de27",
                 "shasum": ""
             },
             "require": {
-                "illuminate/console": "^9.21|^10.0|^11.0|^12.0",
-                "illuminate/filesystem": "^9.21|^10.0|^11.0|^12.0",
-                "illuminate/support": "^9.21|^10.0|^11.0|^12.0",
-                "illuminate/validation": "^9.21|^10.0|^11.0|^12.0",
+                "illuminate/console": "^9.21|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/filesystem": "^9.21|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^9.21|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/validation": "^9.21|^10.0|^11.0|^12.0|^13.0",
                 "php": "^8.0",
-                "symfony/console": "^6.0|^7.0"
+                "symfony/console": "^6.0|^7.0|^8.0"
             },
             "require-dev": {
-                "orchestra/testbench": "^7.35|^8.15|^9.0|^10.0",
-                "phpunit/phpunit": "^9.3|^10.4|^11.5"
+                "orchestra/testbench": "^7.35|^8.15|^9.0|^10.0|^11.0",
+                "phpunit/phpunit": "^9.3|^10.4|^11.5|^12.5|^13.0"
             },
             "type": "library",
             "extra": {
@@ -2238,9 +2244,9 @@
                 "ui"
             ],
             "support": {
-                "source": "https://github.com/laravel/ui/tree/v4.6.1"
+                "source": "https://github.com/laravel/ui/tree/v4.6.3"
             },
-            "time": "2025-01-28T15:15:29+00:00"
+            "time": "2026-03-17T13:41:52+00:00"
         },
         {
             "name": "laravelcollective/html",
@@ -2317,16 +2323,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.7.1",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "10732241927d3971d28e7ea7b5712721fa2296ca"
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/10732241927d3971d28e7ea7b5712721fa2296ca",
-                "reference": "10732241927d3971d28e7ea7b5712721fa2296ca",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
                 "shasum": ""
             },
             "require": {
@@ -2351,9 +2357,9 @@
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
-                "symfony/process": "^5.4 | ^6.0 | ^7.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
             },
@@ -2363,7 +2369,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.8-dev"
+                    "dev-main": "2.9-dev"
                 }
             },
             "autoload": {
@@ -2420,7 +2426,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-20T12:47:49+00:00"
+            "time": "2026-03-19T13:16:38+00:00"
         },
         {
             "name": "league/config",
@@ -2506,16 +2512,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.30.2",
+            "version": "3.35.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "5966a8ba23e62bdb518dd9e0e665c2dbd4b5b277"
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/5966a8ba23e62bdb518dd9e0e665c2dbd4b5b277",
-                "reference": "5966a8ba23e62bdb518dd9e0e665c2dbd4b5b277",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/b277b5dc3d56650b68904117124e79c851e12376",
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376",
                 "shasum": ""
             },
             "require": {
@@ -2583,26 +2589,26 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.30.2"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.35.2"
             },
-            "time": "2025-11-10T17:13:11+00:00"
+            "time": "2026-07-06T14:42:07+00:00"
         },
         {
             "name": "league/flysystem-aws-s3-v3",
-            "version": "3.30.1",
+            "version": "3.35.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
-                "reference": "d286e896083bed3190574b8b088b557b59eb66f5"
+                "reference": "8475ef9adfc6498b85469e2abec6fe3118cd08c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/d286e896083bed3190574b8b088b557b59eb66f5",
-                "reference": "d286e896083bed3190574b8b088b557b59eb66f5",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/8475ef9adfc6498b85469e2abec6fe3118cd08c4",
+                "reference": "8475ef9adfc6498b85469e2abec6fe3118cd08c4",
                 "shasum": ""
             },
             "require": {
-                "aws/aws-sdk-php": "^3.295.10",
+                "aws/aws-sdk-php": "^3.371.5",
                 "league/flysystem": "^3.10.0",
                 "league/mime-type-detection": "^1.0.0",
                 "php": "^8.0.2"
@@ -2638,22 +2644,22 @@
                 "storage"
             ],
             "support": {
-                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/3.30.1"
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/3.35.2"
             },
-            "time": "2025-10-20T15:27:33+00:00"
+            "time": "2026-07-01T23:25:49+00:00"
         },
         {
             "name": "league/flysystem-local",
-            "version": "3.30.2",
+            "version": "3.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-local.git",
-                "reference": "ab4f9d0d672f601b102936aa728801dd1a11968d"
+                "reference": "2f669db18a4c20c755c2bb7d3a7b0b2340488079"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/ab4f9d0d672f601b102936aa728801dd1a11968d",
-                "reference": "ab4f9d0d672f601b102936aa728801dd1a11968d",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/2f669db18a4c20c755c2bb7d3a7b0b2340488079",
+                "reference": "2f669db18a4c20c755c2bb7d3a7b0b2340488079",
                 "shasum": ""
             },
             "require": {
@@ -2687,9 +2693,9 @@
                 "local"
             ],
             "support": {
-                "source": "https://github.com/thephpleague/flysystem-local/tree/3.30.2"
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.31.0"
             },
-            "time": "2025-11-10T11:23:37+00:00"
+            "time": "2026-01-23T15:30:45+00:00"
         },
         {
             "name": "league/glide",
@@ -2887,16 +2893,16 @@
         },
         {
             "name": "maennchen/zipstream-php",
-            "version": "3.2.0",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maennchen/ZipStream-PHP.git",
-                "reference": "9712d8fa4cdf9240380b01eb4be55ad8dcf71416"
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/9712d8fa4cdf9240380b01eb4be55ad8dcf71416",
-                "reference": "9712d8fa4cdf9240380b01eb4be55ad8dcf71416",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
                 "shasum": ""
             },
             "require": {
@@ -2907,7 +2913,7 @@
             "require-dev": {
                 "brianium/paratest": "^7.7",
                 "ext-zip": "*",
-                "friendsofphp/php-cs-fixer": "^3.16",
+                "friendsofphp/php-cs-fixer": "^3.86",
                 "guzzlehttp/guzzle": "^7.5",
                 "mikey179/vfsstream": "^1.6",
                 "php-coveralls/php-coveralls": "^2.5",
@@ -2953,7 +2959,7 @@
             ],
             "support": {
                 "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
-                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.2.0"
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.2.2"
             },
             "funding": [
                 {
@@ -2961,20 +2967,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-17T11:15:13+00:00"
+            "time": "2026-04-11T18:38:28+00:00"
         },
         {
             "name": "monolog/monolog",
-            "version": "3.9.0",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
                 "shasum": ""
             },
             "require": {
@@ -2992,7 +2998,7 @@
                 "graylog2/gelf-php": "^1.4.2 || ^2.0",
                 "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/psr7": "^2.2",
-                "mongodb/mongodb": "^1.8",
+                "mongodb/mongodb": "^1.8 || ^2.0",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
                 "php-console/php-console": "^3.1.8",
                 "phpstan/phpstan": "^2",
@@ -3052,7 +3058,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
             },
             "funding": [
                 {
@@ -3064,20 +3070,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-24T10:02:05+00:00"
+            "time": "2026-01-02T08:56:05+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
-            "version": "2.8.0",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
                 "shasum": ""
             },
             "require": {
@@ -3086,7 +3092,7 @@
             },
             "require-dev": {
                 "composer/xdebug-handler": "^3.0.3",
-                "phpunit/phpunit": "^8.5.33"
+                "phpunit/phpunit": "^8.5.52"
             },
             "bin": [
                 "bin/jp.php"
@@ -3094,7 +3100,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "2.9-dev"
                 }
             },
             "autoload": {
@@ -3128,9 +3134,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jmespath/jmespath.php/issues",
-                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
             },
-            "time": "2024-09-04T18:46:31+00:00"
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -3241,16 +3247,16 @@
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.3",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004"
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/2befc2f42d7c715fd9d95efc31b1081e5d765004",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
                 "shasum": ""
             },
             "require": {
@@ -3258,8 +3264,10 @@
                 "php": "8.1 - 8.5"
             },
             "require-dev": {
-                "nette/tester": "^2.5.2",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -3300,26 +3308,26 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.3"
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
             },
-            "time": "2025-10-30T22:57:59+00:00"
+            "time": "2026-02-23T03:47:12+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.0.8",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "c930ca4e3cf4f17dcfb03037703679d2396d2ede"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/c930ca4e3cf4f17dcfb03037703679d2396d2ede",
-                "reference": "c930ca4e3cf4f17dcfb03037703679d2396d2ede",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
-                "php": "8.0 - 8.5"
+                "php": "8.2 - 8.5"
             },
             "conflict": {
                 "nette/finder": "<3",
@@ -3327,8 +3335,10 @@
             },
             "require-dev": {
                 "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.5",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
                 "tracy/tracy": "^2.9"
             },
             "suggest": {
@@ -3342,7 +3352,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -3389,22 +3399,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.0.8"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2025-08-06T21:43:34+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.4",
+            "version": "v4.19.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
+                "reference": "51bd93cc741b7fc3d63d20b6bdcd99fdaa359837"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
-                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/51bd93cc741b7fc3d63d20b6bdcd99fdaa359837",
+                "reference": "51bd93cc741b7fc3d63d20b6bdcd99fdaa359837",
                 "shasum": ""
             },
             "require": {
@@ -3419,11 +3429,6 @@
                 "bin/php-parse"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.9-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PhpParser\\": "lib/PhpParser"
@@ -3445,9 +3450,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.5"
             },
-            "time": "2024-09-29T15:01:53+00:00"
+            "time": "2025-12-06T11:45:25+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -3614,16 +3619,16 @@
         },
         {
             "name": "owen-it/laravel-auditing",
-            "version": "v13.7.2",
+            "version": "v13.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/owen-it/laravel-auditing.git",
-                "reference": "4f72181622683bc667bbdd2e5fa09cd376329af4"
+                "reference": "ea4d9be9323b3db33d464afd09f954e155d1641b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/owen-it/laravel-auditing/zipball/4f72181622683bc667bbdd2e5fa09cd376329af4",
-                "reference": "4f72181622683bc667bbdd2e5fa09cd376329af4",
+                "url": "https://api.github.com/repos/owen-it/laravel-auditing/zipball/ea4d9be9323b3db33d464afd09f954e155d1641b",
+                "reference": "ea4d9be9323b3db33d464afd09f954e155d1641b",
                 "shasum": ""
             },
             "require": {
@@ -3698,20 +3703,20 @@
                 "issues": "https://github.com/owen-it/laravel-auditing/issues",
                 "source": "https://github.com/owen-it/laravel-auditing"
             },
-            "time": "2025-02-21T14:58:02+00:00"
+            "time": "2026-06-12T14:06:10+00:00"
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.9.4",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d"
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
-                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/75365b91986c2405cf5e1e012c5595cd487a98be",
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be",
                 "shasum": ""
             },
             "require": {
@@ -3761,7 +3766,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.9.4"
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.5"
             },
             "funding": [
                 {
@@ -3773,7 +3778,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-21T11:53:16+00:00"
+            "time": "2025-12-27T19:41:33+00:00"
         },
         {
             "name": "predis/predis",
@@ -4304,16 +4309,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.14",
+            "version": "v0.12.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "95c29b3756a23855a30566b745d218bee690bef2"
+                "reference": "ca0fdcf8a7617afa3adfdf1b5fef573dffb69ca1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/95c29b3756a23855a30566b745d218bee690bef2",
-                "reference": "95c29b3756a23855a30566b745d218bee690bef2",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/ca0fdcf8a7617afa3adfdf1b5fef573dffb69ca1",
+                "reference": "ca0fdcf8a7617afa3adfdf1b5fef573dffb69ca1",
                 "shasum": ""
             },
             "require": {
@@ -4321,8 +4326,8 @@
                 "ext-tokenizer": "*",
                 "nikic/php-parser": "^5.0 || ^4.0",
                 "php": "^8.0 || ^7.4",
-                "symfony/console": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4",
-                "symfony/var-dumper": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4"
+                "symfony/console": "^8.0 || ^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4",
+                "symfony/var-dumper": "^8.0 || ^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4"
             },
             "conflict": {
                 "symfony/console": "4.4.37 || 5.3.14 || 5.3.15 || 5.4.3 || 5.4.4 || 6.0.3 || 6.0.4"
@@ -4377,9 +4382,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.14"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.24"
             },
-            "time": "2025-10-27T17:15:31+00:00"
+            "time": "2026-06-29T15:41:09+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -4503,20 +4508,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.9.1",
+            "version": "4.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "81f941f6f729b1e3ceea61d9d014f8b6c6800440"
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/81f941f6f729b1e3ceea61d9d014f8b6c6800440",
-                "reference": "81f941f6f729b1e3ceea61d9d014f8b6c6800440",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/1df15849d00943a67d677dc9cfd80795f038c9f8",
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13 || ^0.14",
+                "brick/math": ">=0.8.16 <=0.18",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
             },
@@ -4575,22 +4580,22 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.9.1"
+                "source": "https://github.com/ramsey/uuid/tree/4.9.3"
             },
-            "time": "2025-09-04T20:59:21+00:00"
+            "time": "2026-06-18T03:57:49+00:00"
         },
         {
             "name": "sentry/sentry",
-            "version": "4.18.1",
+            "version": "4.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-php.git",
-                "reference": "04dcf20b39742b731b676f8b8d4f02d1db488af8"
+                "reference": "d732a4da195f231cedb2a2a78ae16dd73082afa3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/04dcf20b39742b731b676f8b8d4f02d1db488af8",
-                "reference": "04dcf20b39742b731b676f8b8d4f02d1db488af8",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/d732a4da195f231cedb2a2a78ae16dd73082afa3",
+                "reference": "d732a4da195f231cedb2a2a78ae16dd73082afa3",
                 "shasum": ""
             },
             "require": {
@@ -4607,16 +4612,22 @@
                 "raven/raven": "*"
             },
             "require-dev": {
+                "carthage-software/mago": "1.30.0",
                 "friendsofphp/php-cs-fixer": "^3.4",
                 "guzzlehttp/promises": "^2.0.3",
-                "guzzlehttp/psr7": "^1.8.4|^2.1.1",
                 "monolog/monolog": "^1.6|^2.0|^3.0",
-                "phpbench/phpbench": "^1.0",
+                "nyholm/psr7": "^1.8",
+                "open-telemetry/api": "^1.0",
+                "open-telemetry/exporter-otlp": "^1.0",
+                "open-telemetry/sdk": "^1.0",
+                "open-telemetry/sem-conv": "^1.27",
                 "phpstan/phpstan": "^1.3",
-                "phpunit/phpunit": "^8.5|^9.6",
-                "vimeo/psalm": "^4.17"
+                "phpunit/phpunit": "^8.5.52|^9.6.34",
+                "spiral/roadrunner-http": "^3.6",
+                "spiral/roadrunner-worker": "^3.6"
             },
             "suggest": {
+                "ext-excimer": "Enable Sentry profiling with the Excimer PHP extension.",
                 "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler."
             },
             "type": "library",
@@ -4653,7 +4664,7 @@
             ],
             "support": {
                 "issues": "https://github.com/getsentry/sentry-php/issues",
-                "source": "https://github.com/getsentry/sentry-php/tree/4.18.1"
+                "source": "https://github.com/getsentry/sentry-php/tree/4.29.0"
             },
             "funding": [
                 {
@@ -4665,40 +4676,41 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-11-11T09:34:53+00:00"
+            "time": "2026-06-29T14:47:44+00:00"
         },
         {
             "name": "sentry/sentry-laravel",
-            "version": "4.19.0",
+            "version": "4.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-laravel.git",
-                "reference": "7fdffd57e8fff0a6f9a18d9a83f32e960af63e3f"
+                "reference": "8f2cc669ee99d3cda31a89f0a18197fd2efbd1b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-laravel/zipball/7fdffd57e8fff0a6f9a18d9a83f32e960af63e3f",
-                "reference": "7fdffd57e8fff0a6f9a18d9a83f32e960af63e3f",
+                "url": "https://api.github.com/repos/getsentry/sentry-laravel/zipball/8f2cc669ee99d3cda31a89f0a18197fd2efbd1b6",
+                "reference": "8f2cc669ee99d3cda31a89f0a18197fd2efbd1b6",
                 "shasum": ""
             },
             "require": {
-                "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
+                "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
                 "nyholm/psr7": "^1.0",
                 "php": "^7.2 | ^8.0",
-                "sentry/sentry": "^4.18.0",
-                "symfony/psr-http-message-bridge": "^1.0 | ^2.0 | ^6.0 | ^7.0"
+                "sentry/sentry": "^4.28.0",
+                "symfony/psr-http-message-bridge": "^1.0 | ^2.0 | ^6.0 | ^7.0 | ^8.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.11",
                 "guzzlehttp/guzzle": "^7.2",
                 "laravel/folio": "^1.1",
-                "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
+                "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
+                "laravel/octane": "^2.15",
                 "laravel/pennant": "^1.0",
-                "livewire/livewire": "^2.0 | ^3.0",
+                "livewire/livewire": "^2.0 | ^3.0 | ^4.0",
                 "mockery/mockery": "^1.3",
-                "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
+                "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0",
                 "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^8.4 | ^9.3 | ^10.4 | ^11.5"
+                "phpunit/phpunit": "^8.5 | ^9.6 | ^10.4 | ^11.5"
             },
             "type": "library",
             "extra": {
@@ -4743,7 +4755,7 @@
             ],
             "support": {
                 "issues": "https://github.com/getsentry/sentry-laravel/issues",
-                "source": "https://github.com/getsentry/sentry-laravel/tree/4.19.0"
+                "source": "https://github.com/getsentry/sentry-laravel/tree/4.26.0"
             },
             "funding": [
                 {
@@ -4755,20 +4767,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-11-11T09:01:14+00:00"
+            "time": "2026-06-11T13:22:14+00:00"
         },
         {
             "name": "spatie/browsershot",
-            "version": "5.1.0",
+            "version": "5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/browsershot.git",
-                "reference": "e942e419947c5148f1d0014b334a7de1f6fe5d9a"
+                "reference": "dcf7a65fd1d0fc8fd113739b84982377728d0b2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/browsershot/zipball/e942e419947c5148f1d0014b334a7de1f6fe5d9a",
-                "reference": "e942e419947c5148f1d0014b334a7de1f6fe5d9a",
+                "url": "https://api.github.com/repos/spatie/browsershot/zipball/dcf7a65fd1d0fc8fd113739b84982377728d0b2f",
+                "reference": "dcf7a65fd1d0fc8fd113739b84982377728d0b2f",
                 "shasum": ""
             },
             "require": {
@@ -4776,7 +4788,7 @@
                 "ext-json": "*",
                 "php": "^8.2",
                 "spatie/temporary-directory": "^2.0",
-                "symfony/process": "^6.0|^7.0"
+                "symfony/process": "^6.0|^7.0|^8.0"
             },
             "require-dev": {
                 "pestphp/pest": "^3.0|^4.0",
@@ -4815,7 +4827,7 @@
                 "webpage"
             ],
             "support": {
-                "source": "https://github.com/spatie/browsershot/tree/5.1.0"
+                "source": "https://github.com/spatie/browsershot/tree/5.4.0"
             },
             "funding": [
                 {
@@ -4823,25 +4835,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-17T08:47:07+00:00"
+            "time": "2026-05-26T13:13:33+00:00"
         },
         {
             "name": "spatie/db-dumper",
-            "version": "3.8.0",
+            "version": "3.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/db-dumper.git",
-                "reference": "91e1fd4dc000aefc9753cda2da37069fc996baee"
+                "reference": "eac3221fbe27fac51f388600d27b67b1b079406e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/91e1fd4dc000aefc9753cda2da37069fc996baee",
-                "reference": "91e1fd4dc000aefc9753cda2da37069fc996baee",
+                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/eac3221fbe27fac51f388600d27b67b1b079406e",
+                "reference": "eac3221fbe27fac51f388600d27b67b1b079406e",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.0",
-                "symfony/process": "^5.0|^6.0|^7.0"
+                "symfony/process": "^5.0|^6.0|^7.0|^8.0"
             },
             "require-dev": {
                 "pestphp/pest": "^1.22"
@@ -4874,7 +4886,7 @@
                 "spatie"
             ],
             "support": {
-                "source": "https://github.com/spatie/db-dumper/tree/3.8.0"
+                "source": "https://github.com/spatie/db-dumper/tree/3.8.3"
             },
             "funding": [
                 {
@@ -4886,32 +4898,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-14T15:04:22+00:00"
+            "time": "2026-01-05T16:26:03+00:00"
         },
         {
             "name": "spatie/eloquent-sortable",
-            "version": "4.5.2",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/eloquent-sortable.git",
-                "reference": "c1c4f3a66cd41eb7458783c8a4c8e5d7924a9f20"
+                "reference": "caf2596e5df0260d0e2863e89b750611eef2fc59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/eloquent-sortable/zipball/c1c4f3a66cd41eb7458783c8a4c8e5d7924a9f20",
-                "reference": "c1c4f3a66cd41eb7458783c8a4c8e5d7924a9f20",
+                "url": "https://api.github.com/repos/spatie/eloquent-sortable/zipball/caf2596e5df0260d0e2863e89b750611eef2fc59",
+                "reference": "caf2596e5df0260d0e2863e89b750611eef2fc59",
                 "shasum": ""
             },
             "require": {
-                "illuminate/database": "^9.31|^10.0|^11.0|^12.0",
-                "illuminate/support": "^9.31|^10.0|^11.0|^12.0",
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
                 "nesbot/carbon": "^2.63|^3.0",
-                "php": "^8.1",
+                "php": "^8.2",
                 "spatie/laravel-package-tools": "^1.9"
             },
             "require-dev": {
-                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
-                "phpunit/phpunit": "^9.5|^10.0|^11.5.3"
+                "orchestra/testbench": "^8.0|^9.6|^10.0|^11.0",
+                "phpunit/phpunit": "^10.0|^11.5.3|^12.0"
             },
             "type": "library",
             "extra": {
@@ -4948,7 +4960,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/eloquent-sortable/issues",
-                "source": "https://github.com/spatie/eloquent-sortable/tree/4.5.2"
+                "source": "https://github.com/spatie/eloquent-sortable/tree/5.0.1"
             },
             "funding": [
                 {
@@ -4960,7 +4972,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-25T11:46:57+00:00"
+            "time": "2026-02-21T21:26:43+00:00"
         },
         {
             "name": "spatie/image",
@@ -5033,28 +5045,28 @@
         },
         {
             "name": "spatie/image-optimizer",
-            "version": "1.8.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/image-optimizer.git",
-                "reference": "4fd22035e81d98fffced65a8c20d9ec4daa9671c"
+                "reference": "333c03952289dc2df0a91874636a0dffeb5b6aec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/image-optimizer/zipball/4fd22035e81d98fffced65a8c20d9ec4daa9671c",
-                "reference": "4fd22035e81d98fffced65a8c20d9ec4daa9671c",
+                "url": "https://api.github.com/repos/spatie/image-optimizer/zipball/333c03952289dc2df0a91874636a0dffeb5b6aec",
+                "reference": "333c03952289dc2df0a91874636a0dffeb5b6aec",
                 "shasum": ""
             },
             "require": {
                 "ext-fileinfo": "*",
-                "php": "^7.3|^8.0",
+                "php": "^7.4|^8.0",
                 "psr/log": "^1.0 | ^2.0 | ^3.0",
-                "symfony/process": "^4.2|^5.0|^6.0|^7.0"
+                "symfony/process": "^4.2|^5.0|^6.0|^7.0|^8.0"
             },
             "require-dev": {
-                "pestphp/pest": "^1.21",
-                "phpunit/phpunit": "^8.5.21|^9.4.4",
-                "symfony/var-dumper": "^4.2|^5.0|^6.0|^7.0"
+                "pestphp/pest": "^1.21|^2.0|^3.0|^4.0",
+                "phpunit/phpunit": "^8.5.21|^9.4.4|^10.0|^11.0|^12.0",
+                "symfony/var-dumper": "^4.2|^5.0|^6.0|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5082,9 +5094,9 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/image-optimizer/issues",
-                "source": "https://github.com/spatie/image-optimizer/tree/1.8.0"
+                "source": "https://github.com/spatie/image-optimizer/tree/1.10.0"
             },
-            "time": "2024-11-04T08:24:54+00:00"
+            "time": "2026-06-29T08:28:30+00:00"
         },
         {
             "name": "spatie/laravel-backup",
@@ -5295,29 +5307,29 @@
         },
         {
             "name": "spatie/laravel-package-tools",
-            "version": "1.92.7",
+            "version": "1.93.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-package-tools.git",
-                "reference": "f09a799850b1ed765103a4f0b4355006360c49a5"
+                "reference": "d5552849801f2642aea710557463234b59ef65eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/f09a799850b1ed765103a4f0b4355006360c49a5",
-                "reference": "f09a799850b1ed765103a4f0b4355006360c49a5",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/d5552849801f2642aea710557463234b59ef65eb",
+                "reference": "d5552849801f2642aea710557463234b59ef65eb",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^9.28|^10.0|^11.0|^12.0",
-                "php": "^8.0"
+                "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.5",
-                "orchestra/testbench": "^7.7|^8.0|^9.0|^10.0",
-                "pestphp/pest": "^1.23|^2.1|^3.1",
-                "phpunit/php-code-coverage": "^9.0|^10.0|^11.0",
-                "phpunit/phpunit": "^9.5.24|^10.5|^11.5",
-                "spatie/pest-plugin-test-time": "^1.1|^2.2"
+                "orchestra/testbench": "^8.0|^9.2|^10.0|^11.0",
+                "pestphp/pest": "^2.1|^3.1|^4.0",
+                "phpunit/php-code-coverage": "^10.0|^11.0|^12.0",
+                "phpunit/phpunit": "^10.5|^11.5|^12.5",
+                "spatie/pest-plugin-test-time": "^2.2|^3.0"
             },
             "type": "library",
             "autoload": {
@@ -5344,7 +5356,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-package-tools/issues",
-                "source": "https://github.com/spatie/laravel-package-tools/tree/1.92.7"
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.93.1"
             },
             "funding": [
                 {
@@ -5352,7 +5364,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-17T15:46:43+00:00"
+            "time": "2026-05-19T14:06:37+00:00"
         },
         {
             "name": "spatie/laravel-signal-aware-command",
@@ -5430,30 +5442,30 @@
         },
         {
             "name": "spatie/laravel-tags",
-            "version": "4.10.1",
+            "version": "4.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-tags.git",
-                "reference": "26fe2ad5490e65e2a3475c3fe8a4d9609934aa40"
+                "reference": "5c5fc6bd32d1efbe41bc2520d8a2b4fc38087fb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-tags/zipball/26fe2ad5490e65e2a3475c3fe8a4d9609934aa40",
-                "reference": "26fe2ad5490e65e2a3475c3fe8a4d9609934aa40",
+                "url": "https://api.github.com/repos/spatie/laravel-tags/zipball/5c5fc6bd32d1efbe41bc2520d8a2b4fc38087fb6",
+                "reference": "5c5fc6bd32d1efbe41bc2520d8a2b4fc38087fb6",
                 "shasum": ""
             },
             "require": {
-                "laravel/framework": "^10.0|^11.0|^12.0",
+                "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
                 "nesbot/carbon": "^2.63|^3.0",
                 "php": "^8.1",
-                "spatie/eloquent-sortable": "^4.0",
+                "spatie/eloquent-sortable": "^4.0|^5.0",
                 "spatie/laravel-package-tools": "^1.4",
                 "spatie/laravel-translatable": "^6.0"
             },
             "require-dev": {
-                "orchestra/testbench": "^8.0|^9.0|^10.0",
-                "pestphp/pest": "^1.22|^2.0",
-                "phpunit/phpunit": "^9.5.2"
+                "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+                "pestphp/pest": "^1.22|^2.0|^4.0",
+                "phpunit/phpunit": "^9.5.2|^12.5.12"
             },
             "type": "library",
             "extra": {
@@ -5488,7 +5500,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-tags/issues",
-                "source": "https://github.com/spatie/laravel-tags/tree/4.10.1"
+                "source": "https://github.com/spatie/laravel-tags/tree/4.12.0"
             },
             "funding": [
                 {
@@ -5496,7 +5508,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-13T14:16:14+00:00"
+            "time": "2026-06-20T14:00:15+00:00"
         },
         {
             "name": "spatie/laravel-translatable",
@@ -5583,16 +5595,16 @@
         },
         {
             "name": "spatie/temporary-directory",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/temporary-directory.git",
-                "reference": "580eddfe9a0a41a902cac6eeb8f066b42e65a32b"
+                "reference": "32cbb9645b28839cf4f476708e99a2c70e6802c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/580eddfe9a0a41a902cac6eeb8f066b42e65a32b",
-                "reference": "580eddfe9a0a41a902cac6eeb8f066b42e65a32b",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/32cbb9645b28839cf4f476708e99a2c70e6802c9",
+                "reference": "32cbb9645b28839cf4f476708e99a2c70e6802c9",
                 "shasum": ""
             },
             "require": {
@@ -5628,7 +5640,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/temporary-directory/issues",
-                "source": "https://github.com/spatie/temporary-directory/tree/2.3.0"
+                "source": "https://github.com/spatie/temporary-directory/tree/2.4.0"
             },
             "funding": [
                 {
@@ -5640,7 +5652,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-13T13:04:43+00:00"
+            "time": "2026-06-22T07:55:44+00:00"
         },
         {
             "name": "stevebauman/purify",
@@ -5710,16 +5722,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.27",
+            "version": "v6.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "13d3176cf8ad8ced24202844e9f95af11e2959fc"
+                "reference": "9ef84af84a7b66396da483634227650506428639"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/13d3176cf8ad8ced24202844e9f95af11e2959fc",
-                "reference": "13d3176cf8ad8ced24202844e9f95af11e2959fc",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9ef84af84a7b66396da483634227650506428639",
+                "reference": "9ef84af84a7b66396da483634227650506428639",
                 "shasum": ""
             },
             "require": {
@@ -5784,7 +5796,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.27"
+                "source": "https://github.com/symfony/console/tree/v6.4.42"
             },
             "funding": [
                 {
@@ -5804,20 +5816,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-06T10:25:16+00:00"
+            "time": "2026-06-15T05:35:29+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v7.3.6",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "84321188c4754e64273b46b406081ad9b18e8614"
+                "reference": "b75663ed96cf4756e28e3105476f220f92886cc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/84321188c4754e64273b46b406081ad9b18e8614",
-                "reference": "84321188c4754e64273b46b406081ad9b18e8614",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/b75663ed96cf4756e28e3105476f220f92886cc4",
+                "reference": "b75663ed96cf4756e28e3105476f220f92886cc4",
                 "shasum": ""
             },
             "require": {
@@ -5853,7 +5865,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v7.3.6"
+                "source": "https://github.com/symfony/css-selector/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -5873,20 +5885,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-29T17:24:25+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -5899,7 +5911,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -5924,7 +5936,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -5936,24 +5948,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v6.4.26",
+            "version": "v6.4.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "41bedcaec5b72640b0ec2096547b75fda72ead6c"
+                "reference": "2ea68f0e1835ad6a126f93bbc14cd236c10ab361"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/41bedcaec5b72640b0ec2096547b75fda72ead6c",
-                "reference": "41bedcaec5b72640b0ec2096547b75fda72ead6c",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/2ea68f0e1835ad6a126f93bbc14cd236c10ab361",
+                "reference": "2ea68f0e1835ad6a126f93bbc14cd236c10ab361",
                 "shasum": ""
             },
             "require": {
@@ -5999,7 +6015,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v6.4.26"
+                "source": "https://github.com/symfony/error-handler/tree/v6.4.36"
             },
             "funding": [
                 {
@@ -6019,20 +6035,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T09:57:09+00:00"
+            "time": "2026-03-10T15:56:14+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.3.3",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191"
+                "reference": "51fe3d170227be8d1772214b82ae506e15ed78ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b7dc69e71de420ac04bc9ab830cf3ffebba48191",
-                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/51fe3d170227be8d1772214b82ae506e15ed78ff",
+                "reference": "51fe3d170227be8d1772214b82ae506e15ed78ff",
                 "shasum": ""
             },
             "require": {
@@ -6049,13 +6065,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/error-handler": "^6.4|^7.0",
-                "symfony/expression-language": "^6.4|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^6.4|^7.0"
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6083,7 +6100,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.3.3"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -6103,20 +6120,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T11:49:31+00:00"
+            "time": "2026-06-06T11:10:32+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c7de7a00ffb67842132da02ea92988a39ccd9f4e",
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e",
                 "shasum": ""
             },
             "require": {
@@ -6130,7 +6147,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -6163,7 +6180,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -6175,24 +6192,98 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
-            "name": "symfony/finder",
-            "version": "v6.4.27",
+            "name": "symfony/filesystem",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "a1b6aa435d2fba50793b994a839c32b6064f063b"
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/a1b6aa435d2fba50793b994a839c32b6064f063b",
-                "reference": "a1b6aa435d2fba50793b994a839c32b6064f063b",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-11T16:38:44+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v6.4.42",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "0b73dac42493acbadbba644207a715b254e9b029"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0b73dac42493acbadbba644207a715b254e9b029",
+                "reference": "0b73dac42493acbadbba644207a715b254e9b029",
                 "shasum": ""
             },
             "require": {
@@ -6227,7 +6318,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.4.27"
+                "source": "https://github.com/symfony/finder/tree/v6.4.42"
             },
             "funding": [
                 {
@@ -6247,20 +6338,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-15T18:32:00+00:00"
+            "time": "2026-06-26T15:18:24+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.4.29",
+            "version": "v6.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "b03d11e015552a315714c127d8d1e0f9e970ec88"
+                "reference": "23dcf8e0f59cbbfa9d2894f58fd8be6833794372"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/b03d11e015552a315714c127d8d1e0f9e970ec88",
-                "reference": "b03d11e015552a315714c127d8d1e0f9e970ec88",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/23dcf8e0f59cbbfa9d2894f58fd8be6833794372",
+                "reference": "23dcf8e0f59cbbfa9d2894f58fd8be6833794372",
                 "shasum": ""
             },
             "require": {
@@ -6308,7 +6399,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.4.29"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.42"
             },
             "funding": [
                 {
@@ -6328,20 +6419,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-08T16:40:12+00:00"
+            "time": "2026-06-16T10:12:24+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.4.29",
+            "version": "v6.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "18818b48f54c1d2bd92b41d82d8345af50b15658"
+                "reference": "51fd5bb7d4f221ceeac927e14ade63962e27a47c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/18818b48f54c1d2bd92b41d82d8345af50b15658",
-                "reference": "18818b48f54c1d2bd92b41d82d8345af50b15658",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/51fd5bb7d4f221ceeac927e14ade63962e27a47c",
+                "reference": "51fd5bb7d4f221ceeac927e14ade63962e27a47c",
                 "shasum": ""
             },
             "require": {
@@ -6382,7 +6473,7 @@
                 "symfony/config": "^6.1|^7.0",
                 "symfony/console": "^5.4|^6.0|^7.0",
                 "symfony/css-selector": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4.1|^7.0.1",
                 "symfony/dom-crawler": "^5.4|^6.0|^7.0",
                 "symfony/expression-language": "^5.4|^6.0|^7.0",
                 "symfony/finder": "^5.4|^6.0|^7.0",
@@ -6426,7 +6517,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.4.29"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.4.42"
             },
             "funding": [
                 {
@@ -6446,20 +6537,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-12T11:22:59+00:00"
+            "time": "2026-06-27T09:10:20+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v6.4.27",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "2f096718ed718996551f66e3a24e12b2ed027f95"
+                "reference": "94fd44f3052e02340b0dd4447a7d7a5856e32da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/2f096718ed718996551f66e3a24e12b2ed027f95",
-                "reference": "2f096718ed718996551f66e3a24e12b2ed027f95",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/94fd44f3052e02340b0dd4447a7d7a5856e32da2",
+                "reference": "94fd44f3052e02340b0dd4447a7d7a5856e32da2",
                 "shasum": ""
             },
             "require": {
@@ -6510,7 +6601,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v6.4.27"
+                "source": "https://github.com/symfony/mailer/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -6530,20 +6621,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-24T13:29:09+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v6.4.26",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "61ab9681cdfe315071eb4fa79b6ad6ab030a9235"
+                "reference": "5575d37f8841e4e31d5df79ab3db078ae557ff8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/61ab9681cdfe315071eb4fa79b6ad6ab030a9235",
-                "reference": "61ab9681cdfe315071eb4fa79b6ad6ab030a9235",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/5575d37f8841e4e31d5df79ab3db078ae557ff8e",
+                "reference": "5575d37f8841e4e31d5df79ab3db078ae557ff8e",
                 "shasum": ""
             },
             "require": {
@@ -6599,7 +6690,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.4.26"
+                "source": "https://github.com/symfony/mime/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -6619,20 +6710,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-16T08:22:30+00:00"
+            "time": "2026-05-23T14:40:34+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v7.3.3",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "0ff2f5c3df08a395232bbc3c2eb7e84912df911d"
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/0ff2f5c3df08a395232bbc3c2eb7e84912df911d",
-                "reference": "0ff2f5c3df08a395232bbc3c2eb7e84912df911d",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
                 "shasum": ""
             },
             "require": {
@@ -6670,7 +6761,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.3.3"
+                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -6690,20 +6781,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-05T10:16:07+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -6753,7 +6844,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -6773,20 +6864,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -6835,7 +6926,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6855,20 +6946,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -6922,7 +7013,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6942,20 +7033,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -7007,7 +7098,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -7027,20 +7118,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -7092,7 +7183,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -7112,20 +7203,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -7176,7 +7267,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -7196,20 +7287,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
@@ -7256,7 +7347,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -7276,20 +7367,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-05-27T06:51:48+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2"
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
                 "shasum": ""
             },
             "require": {
@@ -7339,7 +7430,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -7359,20 +7450,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.26",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "48bad913268c8cafabbf7034b39c8bb24fbc5ab8"
+                "reference": "c8fc09bdfe9fde9aaa89b415a4477feaccec16a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/48bad913268c8cafabbf7034b39c8bb24fbc5ab8",
-                "reference": "48bad913268c8cafabbf7034b39c8bb24fbc5ab8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c8fc09bdfe9fde9aaa89b415a4477feaccec16a7",
+                "reference": "c8fc09bdfe9fde9aaa89b415a4477feaccec16a7",
                 "shasum": ""
             },
             "require": {
@@ -7404,7 +7495,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.26"
+                "source": "https://github.com/symfony/process/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -7424,26 +7515,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T09:57:09+00:00"
+            "time": "2026-05-23T13:47:21+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
-            "version": "v7.3.0",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/psr-http-message-bridge.git",
-                "reference": "03f2f72319e7acaf2a9f6fcbe30ef17eec51594f"
+                "reference": "76f1a57719a4a04c0ea18678a6c9305b5dcb9da8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/03f2f72319e7acaf2a9f6fcbe30ef17eec51594f",
-                "reference": "03f2f72319e7acaf2a9f6fcbe30ef17eec51594f",
+                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/76f1a57719a4a04c0ea18678a6c9305b5dcb9da8",
+                "reference": "76f1a57719a4a04c0ea18678a6c9305b5dcb9da8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
                 "psr/http-message": "^1.0|^2.0",
-                "symfony/http-foundation": "^6.4|^7.0"
+                "symfony/http-foundation": "^6.4|^7.0|^8.0"
             },
             "conflict": {
                 "php-http/discovery": "<1.15",
@@ -7453,11 +7544,12 @@
                 "nyholm/psr7": "^1.1",
                 "php-http/discovery": "^1.15",
                 "psr/log": "^1.1.4|^2|^3",
-                "symfony/browser-kit": "^6.4|^7.0",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/framework-bundle": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0"
+                "symfony/browser-kit": "^6.4|^7.0|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4.13|^7.1.6|^8.0",
+                "symfony/http-kernel": "^6.4.13|^7.1.6|^8.0",
+                "symfony/runtime": "^6.4.13|^7.1.6|^8.0"
             },
             "type": "symfony-bridge",
             "autoload": {
@@ -7491,7 +7583,7 @@
                 "psr-7"
             ],
             "support": {
-                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v7.3.0"
+                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -7503,24 +7595,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-26T08:57:56+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v6.4.28",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "ae064a6d9cf39507f9797658465a2ca702965fa8"
+                "reference": "af04c79671fd8df0805a44c83fa2b0ba56c8329e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/ae064a6d9cf39507f9797658465a2ca702965fa8",
-                "reference": "ae064a6d9cf39507f9797658465a2ca702965fa8",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/af04c79671fd8df0805a44c83fa2b0ba56c8329e",
+                "reference": "af04c79671fd8df0805a44c83fa2b0ba56c8329e",
                 "shasum": ""
             },
             "require": {
@@ -7574,7 +7670,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.4.28"
+                "source": "https://github.com/symfony/routing/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -7594,20 +7690,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-31T16:43:05+00:00"
+            "time": "2026-05-24T11:18:16+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -7625,7 +7721,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -7661,7 +7757,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -7681,26 +7777,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.3.4",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f96476035142921000338bad71e5247fbc138872"
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f96476035142921000338bad71e5247fbc138872",
-                "reference": "f96476035142921000338bad71e5247fbc138872",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-grapheme": "~1.33",
                 "symfony/polyfill-intl-normalizer": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
@@ -7708,11 +7805,11 @@
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1",
-                "symfony/http-client": "^6.4|^7.0",
-                "symfony/intl": "^6.4|^7.0",
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0"
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -7751,7 +7848,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.3.4"
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -7771,20 +7868,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T14:36:48+00:00"
+            "time": "2026-05-23T15:23:29+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v6.4.26",
+            "version": "v6.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "c8559fe25c7ee7aa9d28f228903a46db008156a4"
+                "reference": "fef99cef37890b350976f5f492854faefadd4e15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/c8559fe25c7ee7aa9d28f228903a46db008156a4",
-                "reference": "c8559fe25c7ee7aa9d28f228903a46db008156a4",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/fef99cef37890b350976f5f492854faefadd4e15",
+                "reference": "fef99cef37890b350976f5f492854faefadd4e15",
                 "shasum": ""
             },
             "require": {
@@ -7850,7 +7947,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v6.4.26"
+                "source": "https://github.com/symfony/translation/tree/v6.4.42"
             },
             "funding": [
                 {
@@ -7870,20 +7967,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-05T18:17:25+00:00"
+            "time": "2026-06-05T16:46:18+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977"
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/65a8bc82080447fae78373aa10f8d13b38338977",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/ccb206b98faccc511ebae8e5fad50f2dc0b30621",
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621",
                 "shasum": ""
             },
             "require": {
@@ -7896,7 +7993,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -7932,7 +8029,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -7952,20 +8049,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/uid",
-            "version": "v6.4.24",
+            "version": "v6.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "17da16a750541a42cf2183935e0f6008316c23f7"
+                "reference": "6b973c385f00341b246f697d82dc01a09107acdd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/17da16a750541a42cf2183935e0f6008316c23f7",
-                "reference": "17da16a750541a42cf2183935e0f6008316c23f7",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/6b973c385f00341b246f697d82dc01a09107acdd",
+                "reference": "6b973c385f00341b246f697d82dc01a09107acdd",
                 "shasum": ""
             },
             "require": {
@@ -8010,7 +8107,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v6.4.24"
+                "source": "https://github.com/symfony/uid/tree/v6.4.32"
             },
             "funding": [
                 {
@@ -8030,20 +8127,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T08:14:14+00:00"
+            "time": "2025-12-23T15:07:59+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.4.26",
+            "version": "v6.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "cfae1497a2f1eaad78dbc0590311c599c7178d4a"
+                "reference": "29adc5e34255f42ca9b8ae61c22b4d9e3f611317"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/cfae1497a2f1eaad78dbc0590311c599c7178d4a",
-                "reference": "cfae1497a2f1eaad78dbc0590311c599c7178d4a",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/29adc5e34255f42ca9b8ae61c22b4d9e3f611317",
+                "reference": "29adc5e34255f42ca9b8ae61c22b4d9e3f611317",
                 "shasum": ""
             },
             "require": {
@@ -8098,7 +8195,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.4.26"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.4.42"
             },
             "funding": [
                 {
@@ -8118,7 +8215,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-25T15:37:27+00:00"
+            "time": "2026-06-08T07:06:12+00:00"
         },
         {
             "name": "tightenco/collect",
@@ -8177,23 +8274,23 @@
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
-            "version": "v2.3.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
-                "reference": "0d72ac1c00084279c1816675284073c5a337c20d"
+                "reference": "f0292ccf0ec75843d65027214426b6b163b48b41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/0d72ac1c00084279c1816675284073c5a337c20d",
-                "reference": "0d72ac1c00084279c1816675284073c5a337c20d",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/f0292ccf0ec75843d65027214426b6b163b48b41",
+                "reference": "f0292ccf0ec75843d65027214426b6b163b48b41",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "php": "^7.4 || ^8.0",
-                "symfony/css-selector": "^5.4 || ^6.0 || ^7.0"
+                "symfony/css-selector": "^5.4 || ^6.0 || ^7.0 || ^8.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^2.0",
@@ -8226,32 +8323,32 @@
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
             "support": {
                 "issues": "https://github.com/tijsverkoyen/CssToInlineStyles/issues",
-                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/v2.3.0"
+                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/v2.4.0"
             },
-            "time": "2024-12-21T16:25:41+00:00"
+            "time": "2025-12-02T11:56:42+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.2",
+            "version": "v5.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af"
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
-                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/416df702837983f8d5ff48c9c3fee4f5f57b980b",
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b",
                 "shasum": ""
             },
             "require": {
                 "ext-pcre": "*",
-                "graham-campbell/result-type": "^1.1.3",
+                "graham-campbell/result-type": "^1.1.4",
                 "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.3",
-                "symfony/polyfill-ctype": "^1.24",
-                "symfony/polyfill-mbstring": "^1.24",
-                "symfony/polyfill-php80": "^1.24"
+                "phpoption/phpoption": "^1.9.5",
+                "symfony/polyfill-ctype": "^1.26",
+                "symfony/polyfill-mbstring": "^1.26",
+                "symfony/polyfill-php80": "^1.26"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
@@ -8300,7 +8397,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.2"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.4"
             },
             "funding": [
                 {
@@ -8312,27 +8409,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-30T23:37:27+00:00"
+            "time": "2026-07-06T19:11:50+00:00"
         },
         {
             "name": "voku/portable-ascii",
-            "version": "2.0.3",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d"
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/8e1051fe39379367aecf014f41744ce7539a856f",
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+                "phpunit/phpunit": "~8.5 || ~9.6 || ~10.5 || ~11.5"
             },
             "suggest": {
                 "ext-intl": "Use Intl for transliterator_transliterate() support"
@@ -8362,7 +8459,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/2.0.3"
+                "source": "https://github.com/voku/portable-ascii/tree/2.1.1"
             },
             "funding": [
                 {
@@ -8386,7 +8483,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-21T01:49:47+00:00"
+            "time": "2026-04-26T05:33:54+00:00"
         }
     ],
     "packages-dev": [
@@ -8641,16 +8738,16 @@
         },
         {
             "name": "barryvdh/reflection-docblock",
-            "version": "v2.4.0",
+            "version": "v2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/barryvdh/ReflectionDocBlock.git",
-                "reference": "d103774cbe7e94ddee7e4870f97f727b43fe7201"
+                "reference": "4f5ba70c30c81f2ce03a16a9965832cfcc31ed3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/barryvdh/ReflectionDocBlock/zipball/d103774cbe7e94ddee7e4870f97f727b43fe7201",
-                "reference": "d103774cbe7e94ddee7e4870f97f727b43fe7201",
+                "url": "https://api.github.com/repos/barryvdh/ReflectionDocBlock/zipball/4f5ba70c30c81f2ce03a16a9965832cfcc31ed3b",
+                "reference": "4f5ba70c30c81f2ce03a16a9965832cfcc31ed3b",
                 "shasum": ""
             },
             "require": {
@@ -8687,9 +8784,9 @@
                 }
             ],
             "support": {
-                "source": "https://github.com/barryvdh/ReflectionDocBlock/tree/v2.4.0"
+                "source": "https://github.com/barryvdh/ReflectionDocBlock/tree/v2.4.1"
             },
-            "time": "2025-07-17T06:07:30+00:00"
+            "time": "2026-03-05T20:09:01+00:00"
         },
         {
             "name": "beyondcode/laravel-dump-server",
@@ -8758,22 +8855,22 @@
         },
         {
             "name": "composer/class-map-generator",
-            "version": "1.6.2",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/class-map-generator.git",
-                "reference": "ba9f089655d4cdd64e762a6044f411ccdaec0076"
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/ba9f089655d4cdd64e762a6044f411ccdaec0076",
-                "reference": "ba9f089655d4cdd64e762a6044f411ccdaec0076",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/86d8208fc3c649a3a999daf1a63c25201be2990f",
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f",
                 "shasum": ""
             },
             "require": {
                 "composer/pcre": "^2.1 || ^3.1",
                 "php": "^7.2 || ^8.0",
-                "symfony/finder": "^4.4 || ^5.3 || ^6 || ^7"
+                "symfony/finder": "^4.4 || ^5.3 || ^6 || ^7 || ^8"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.12 || ^2",
@@ -8781,7 +8878,7 @@
                 "phpstan/phpstan-phpunit": "^1 || ^2",
                 "phpstan/phpstan-strict-rules": "^1.1 || ^2",
                 "phpunit/phpunit": "^8",
-                "symfony/filesystem": "^5.4 || ^6"
+                "symfony/filesystem": "^5.4 || ^6 || ^7 || ^8"
             },
             "type": "library",
             "extra": {
@@ -8811,7 +8908,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/class-map-generator/issues",
-                "source": "https://github.com/composer/class-map-generator/tree/1.6.2"
+                "source": "https://github.com/composer/class-map-generator/tree/1.7.3"
             },
             "funding": [
                 {
@@ -8823,32 +8920,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-20T18:52:43+00:00"
+            "time": "2026-05-05T09:17:07+00:00"
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -8886,7 +8984,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -8896,13 +8994,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "composer/semver",
@@ -9794,20 +9888,21 @@
         },
         {
             "name": "orchestra/sidekick",
-            "version": "v1.2.17",
+            "version": "v1.2.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/sidekick.git",
-                "reference": "371ce2882ee3f5bf826b36e75d461e51c9cd76c2"
+                "reference": "267a71b56cb2fe1a634d69fc99889c671b77ff43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/sidekick/zipball/371ce2882ee3f5bf826b36e75d461e51c9cd76c2",
-                "reference": "371ce2882ee3f5bf826b36e75d461e51c9cd76c2",
+                "url": "https://api.github.com/repos/orchestral/sidekick/zipball/267a71b56cb2fe1a634d69fc99889c671b77ff43",
+                "reference": "267a71b56cb2fe1a634d69fc99889c671b77ff43",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
+                "composer/semver": "^3.0",
                 "php": "^8.1",
                 "symfony/polyfill-php83": "^1.32"
             },
@@ -9825,6 +9920,7 @@
             "autoload": {
                 "files": [
                     "src/Eloquent/functions.php",
+                    "src/Filesystem/functions.php",
                     "src/Http/functions.php",
                     "src/functions.php"
                 ],
@@ -9845,47 +9941,48 @@
             "description": "Packages Toolkit Utilities and Helpers for Laravel",
             "support": {
                 "issues": "https://github.com/orchestral/sidekick/issues",
-                "source": "https://github.com/orchestral/sidekick/tree/v1.2.17"
+                "source": "https://github.com/orchestral/sidekick/tree/v1.2.20"
             },
-            "time": "2025-10-02T11:02:26+00:00"
+            "time": "2026-01-12T11:09:33+00:00"
         },
         {
             "name": "orchestra/testbench-core",
-            "version": "v8.39.0",
+            "version": "v8.43.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "d685c450be94ced6bfdbbfa410be8b5ff4e9b7ba"
+                "reference": "0952b15ea1dd9c7b7cf9a91b9dd043f3347bc73e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/d685c450be94ced6bfdbbfa410be8b5ff4e9b7ba",
-                "reference": "d685c450be94ced6bfdbbfa410be8b5ff4e9b7ba",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/0952b15ea1dd9c7b7cf9a91b9dd043f3347bc73e",
+                "reference": "0952b15ea1dd9c7b7cf9a91b9dd043f3347bc73e",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
-                "orchestra/sidekick": "~1.1.20|~1.2.17",
+                "orchestra/sidekick": "~1.1.23|~1.2.20",
                 "php": "^8.1",
                 "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-php83": "^1.32"
+                "symfony/polyfill-php83": "^1.33"
             },
             "conflict": {
                 "brianium/paratest": "<6.4.0|>=7.0.0 <7.1.4|>=8.0.0",
-                "laravel/framework": "<10.48.29|>=11.0.0",
+                "laravel/framework": "<10.50.0|>=11.0.0",
                 "laravel/serializable-closure": "<1.3.0|>=3.0.0",
                 "nunomaduro/collision": "<6.4.0|>=7.0.0 <7.4.0|>=8.0.0",
                 "orchestra/testbench-dusk": "<8.32.0|>=9.0.0",
                 "orchestra/workbench": "<1.0.0",
+                "pestphp/pest": "<2.0.0",
                 "phpunit/phpunit": "<9.6.0|>=10.3.0 <10.3.3|>=10.6.0"
             },
             "require-dev": {
                 "fakerphp/faker": "^1.21",
-                "laravel/framework": "^10.48.29",
+                "laravel/framework": "^10.50.0",
                 "laravel/pint": "^1.20",
                 "laravel/serializable-closure": "^1.3|^2.0",
                 "mockery/mockery": "^1.5.1",
-                "phpstan/phpstan": "^2.1.14",
+                "phpstan/phpstan": "^2.1.33",
                 "phpunit/phpunit": "^10.1",
                 "spatie/laravel-ray": "^1.40.2",
                 "symfony/process": "^6.2",
@@ -9943,7 +10040,7 @@
                 "issues": "https://github.com/orchestral/testbench/issues",
                 "source": "https://github.com/orchestral/testbench-core"
             },
-            "time": "2025-10-14T11:36:58+00:00"
+            "time": "2026-04-24T08:19:22+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -10118,16 +10215,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.3",
+            "version": "5.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9"
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94f8051919d1b0369a6bcc7931d679a511c03fe9",
-                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/31a105931bc8ffa3a123383829772e832fd8d903",
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903",
                 "shasum": ""
             },
             "require": {
@@ -10137,7 +10234,7 @@
                 "phpdocumentor/reflection-common": "^2.2",
                 "phpdocumentor/type-resolver": "^1.7",
                 "phpstan/phpdoc-parser": "^1.7|^2.0",
-                "webmozart/assert": "^1.9.1"
+                "webmozart/assert": "^1.9.1 || ^2"
             },
             "require-dev": {
                 "mockery/mockery": "~1.3.5 || ~1.6.0",
@@ -10176,22 +10273,22 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.3"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.7"
             },
-            "time": "2025-08-01T19:43:32+00:00"
+            "time": "2026-03-18T20:47:46+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.10.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a"
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/679e3ce485b99e84c775d28e2e96fade9a7fb50a",
-                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
                 "shasum": ""
             },
             "require": {
@@ -10234,22 +10331,22 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.10.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
             },
-            "time": "2024-11-09T15:12:26+00:00"
+            "time": "2025-11-21T15:09:14+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.0",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
                 "shasum": ""
             },
             "require": {
@@ -10281,9 +10378,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
-            "time": "2025-08-30T15:50:23+00:00"
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -10608,24 +10705,24 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.58",
+            "version": "10.5.64",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca"
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e24fb46da450d8e6a5788670513c1af1424f16ca",
-                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
@@ -10638,7 +10735,7 @@
                 "phpunit/php-timer": "^6.0.0",
                 "sebastian/cli-parser": "^2.0.1",
                 "sebastian/code-unit": "^2.0.0",
-                "sebastian/comparator": "^5.0.4",
+                "sebastian/comparator": "^5.0.5",
                 "sebastian/diff": "^5.1.1",
                 "sebastian/environment": "^6.1.0",
                 "sebastian/exporter": "^5.1.4",
@@ -10689,48 +10786,32 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.58"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.64"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2025-09-28T12:04:46+00:00"
+            "time": "2026-07-06T14:50:35+00:00"
         },
         {
             "name": "psalm/plugin-laravel",
-            "version": "v2.12.1",
+            "version": "v2.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/psalm-plugin-laravel.git",
-                "reference": "c7910a1e199fe26812df2381ede086aaa256d222"
+                "reference": "f1c56d04b162abede17907da75bc468d2bc093ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/psalm/psalm-plugin-laravel/zipball/c7910a1e199fe26812df2381ede086aaa256d222",
-                "reference": "c7910a1e199fe26812df2381ede086aaa256d222",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-laravel/zipball/f1c56d04b162abede17907da75bc468d2bc093ec",
+                "reference": "f1c56d04b162abede17907da75bc468d2bc093ec",
                 "shasum": ""
             },
             "require": {
-                "barryvdh/laravel-ide-helper": "^2.13 || ^3.0",
+                "barryvdh/laravel-ide-helper": "^2.15 || >=3.4.0 <3.6",
                 "ext-simplexml": "*",
                 "illuminate/config": "^10.48 || ^11.0",
                 "illuminate/container": "^10.48 || ^11.0",
@@ -10746,7 +10827,7 @@
                 "php": "^8.1",
                 "symfony/console": "^6.0 || ^7.0",
                 "symfony/finder": "^6.0 || ^7.0",
-                "vimeo/psalm": "^5.20|^6"
+                "vimeo/psalm": "^5.20 || ^6"
             },
             "require-dev": {
                 "laravel/framework": "^10.48 || ^11.0",
@@ -10781,11 +10862,23 @@
             ],
             "description": "Psalm plugin for Laravel",
             "homepage": "https://github.com/psalm/psalm-plugin-laravel",
+            "keywords": [
+                "dev",
+                "laravel",
+                "psalm",
+                "psalm-plugin"
+            ],
             "support": {
                 "issues": "https://github.com/psalm/psalm-plugin-laravel/issues",
-                "source": "https://github.com/psalm/psalm-plugin-laravel/tree/v2.12.1"
+                "source": "https://github.com/psalm/psalm-plugin-laravel/tree/v2.12.3"
             },
-            "time": "2025-02-16T19:03:28+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/alies-dev",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-23T17:37:45+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -10957,16 +11050,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.4",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e"
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e8e53097718d2b53cfb2aa859b06a41abf58c62e",
-                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
                 "shasum": ""
             },
             "require": {
@@ -11022,7 +11115,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.4"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
             },
             "funding": [
                 {
@@ -11042,7 +11135,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-07T05:25:07+00:00"
+            "time": "2026-01-24T09:25:16+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -11742,16 +11835,16 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "3.4.1",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "6a740f39415aee8886aea10333403adc77d50791"
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/6a740f39415aee8886aea10333403adc77d50791",
-                "reference": "6a740f39415aee8886aea10333403adc77d50791",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/88b2f3852a922dd73177a68938f8eb2ec70c7224",
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224",
                 "shasum": ""
             },
             "require": {
@@ -11794,7 +11887,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/3.4.1"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.4.4"
             },
             "funding": [
                 {
@@ -11806,20 +11899,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-12T10:32:50+00:00"
+            "time": "2025-12-15T09:00:41+00:00"
         },
         {
             "name": "spatie/backtrace",
-            "version": "1.8.1",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/backtrace.git",
-                "reference": "8c0f16a59ae35ec8c62d85c3c17585158f430110"
+                "reference": "8ffe78be5ed355b5009e3dd989d183433e9a5adc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/backtrace/zipball/8c0f16a59ae35ec8c62d85c3c17585158f430110",
-                "reference": "8c0f16a59ae35ec8c62d85c3c17585158f430110",
+                "url": "https://api.github.com/repos/spatie/backtrace/zipball/8ffe78be5ed355b5009e3dd989d183433e9a5adc",
+                "reference": "8ffe78be5ed355b5009e3dd989d183433e9a5adc",
                 "shasum": ""
             },
             "require": {
@@ -11830,7 +11923,7 @@
                 "laravel/serializable-closure": "^1.3 || ^2.0",
                 "phpunit/phpunit": "^9.3 || ^11.4.3",
                 "spatie/phpunit-snapshot-assertions": "^4.2 || ^5.1.6",
-                "symfony/var-dumper": "^5.1 || ^6.0 || ^7.0"
+                "symfony/var-dumper": "^5.1|^6.0|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -11858,7 +11951,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/backtrace/issues",
-                "source": "https://github.com/spatie/backtrace/tree/1.8.1"
+                "source": "https://github.com/spatie/backtrace/tree/1.8.2"
             },
             "funding": [
                 {
@@ -11870,7 +11963,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2025-08-26T08:22:30+00:00"
+            "time": "2026-03-11T13:48:28+00:00"
         },
         {
             "name": "spatie/error-solutions",
@@ -11948,26 +12041,26 @@
         },
         {
             "name": "spatie/flare-client-php",
-            "version": "1.10.1",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/flare-client-php.git",
-                "reference": "bf1716eb98bd689451b071548ae9e70738dce62f"
+                "reference": "53f41b08a27cc039e1a8ed2be9a202e924f31bad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/flare-client-php/zipball/bf1716eb98bd689451b071548ae9e70738dce62f",
-                "reference": "bf1716eb98bd689451b071548ae9e70738dce62f",
+                "url": "https://api.github.com/repos/spatie/flare-client-php/zipball/53f41b08a27cc039e1a8ed2be9a202e924f31bad",
+                "reference": "53f41b08a27cc039e1a8ed2be9a202e924f31bad",
                 "shasum": ""
             },
             "require": {
-                "illuminate/pipeline": "^8.0|^9.0|^10.0|^11.0|^12.0",
+                "illuminate/pipeline": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
                 "php": "^8.0",
                 "spatie/backtrace": "^1.6.1",
-                "symfony/http-foundation": "^5.2|^6.0|^7.0",
-                "symfony/mime": "^5.2|^6.0|^7.0",
-                "symfony/process": "^5.2|^6.0|^7.0",
-                "symfony/var-dumper": "^5.2|^6.0|^7.0"
+                "symfony/http-foundation": "^5.2|^6.0|^7.0|^8.0",
+                "symfony/mime": "^5.2|^6.0|^7.0|^8.0",
+                "symfony/process": "^5.2|^6.0|^7.0|^8.0",
+                "symfony/var-dumper": "^5.2|^6.0|^7.0|^8.0"
             },
             "require-dev": {
                 "dms/phpunit-arraysubset-asserts": "^0.5.0",
@@ -12005,7 +12098,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/flare-client-php/issues",
-                "source": "https://github.com/spatie/flare-client-php/tree/1.10.1"
+                "source": "https://github.com/spatie/flare-client-php/tree/1.11.1"
             },
             "funding": [
                 {
@@ -12013,41 +12106,44 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-14T13:42:06+00:00"
+            "time": "2026-05-15T09:31:32+00:00"
         },
         {
             "name": "spatie/ignition",
-            "version": "1.15.1",
+            "version": "1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/ignition.git",
-                "reference": "31f314153020aee5af3537e507fef892ffbf8c85"
+                "reference": "b59385bb7aa24dae81bcc15850ebecfda7b40838"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/ignition/zipball/31f314153020aee5af3537e507fef892ffbf8c85",
-                "reference": "31f314153020aee5af3537e507fef892ffbf8c85",
+                "url": "https://api.github.com/repos/spatie/ignition/zipball/b59385bb7aa24dae81bcc15850ebecfda7b40838",
+                "reference": "b59385bb7aa24dae81bcc15850ebecfda7b40838",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-mbstring": "*",
                 "php": "^8.0",
-                "spatie/error-solutions": "^1.0",
-                "spatie/flare-client-php": "^1.7",
-                "symfony/console": "^5.4|^6.0|^7.0",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+                "spatie/backtrace": "^1.7.1",
+                "spatie/error-solutions": "^1.1.2",
+                "spatie/flare-client-php": "^1.9",
+                "symfony/console": "^5.4.42|^6.0|^7.0|^8.0",
+                "symfony/http-foundation": "^5.4.42|^6.0|^7.0|^8.0",
+                "symfony/mime": "^5.4.42|^6.0|^7.0|^8.0",
+                "symfony/var-dumper": "^5.4.42|^6.0|^7.0|^8.0"
             },
             "require-dev": {
-                "illuminate/cache": "^9.52|^10.0|^11.0|^12.0",
+                "illuminate/cache": "^9.52|^10.0|^11.0|^12.0|^13.0",
                 "mockery/mockery": "^1.4",
-                "pestphp/pest": "^1.20|^2.0",
+                "pestphp/pest": "^1.20|^2.0|^3.0",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan-deprecation-rules": "^1.0",
                 "phpstan/phpstan-phpunit": "^1.0",
                 "psr/simple-cache-implementation": "*",
-                "symfony/cache": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
+                "symfony/cache": "^5.4.38|^6.0|^7.0|^8.0",
+                "symfony/process": "^5.4.35|^6.0|^7.0|^8.0",
                 "vlucas/phpdotenv": "^5.5"
             },
             "suggest": {
@@ -12096,7 +12192,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-21T14:31:39+00:00"
+            "time": "2026-03-17T10:51:08+00:00"
         },
         {
             "name": "spatie/laravel-ignition",
@@ -12235,76 +12331,6 @@
                 "source": "https://github.com/sunra/php-simple-html-dom-parser/tree/master"
             },
             "time": "2016-05-20T11:21:15+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v7.3.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "e9bcfd7837928ab656276fe00464092cc9e1826a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e9bcfd7837928ab656276fe00464092cc9e1826a",
-                "reference": "e9bcfd7837928ab656276fe00464092cc9e1826a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "require-dev": {
-                "symfony/process": "^6.4|^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.3.6"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-11-05T09:52:27+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -12468,23 +12494,23 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.12.1",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
                 "ext-date": "*",
                 "ext-filter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.2"
             },
             "suggest": {
                 "ext-intl": "",
@@ -12493,8 +12519,12 @@
             },
             "type": "library",
             "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
                 "branch-alias": {
-                    "dev-master": "1.10-dev"
+                    "dev-master": "2.0-dev",
+                    "dev-feature/2-0": "2.0-dev"
                 }
             },
             "autoload": {
@@ -12510,6 +12540,10 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
                 }
             ],
             "description": "Assertions to validate method input/output with nice error messages.",
@@ -12520,19 +12554,19 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
+                "source": "https://github.com/webmozarts/assert/tree/2.4.1"
             },
-            "time": "2025-10-29T15:56:20+00:00"
+            "time": "2026-06-15T15:31:57+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.3.0"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ff5298aa8683b4eae7f0de259ddc9c2",
+    "content-hash": "9fdbdc552d45f04ff380c62d5a8f0e53",
     "packages": [
         {
             "name": "adldap2/adldap2",
@@ -410,6 +410,83 @@
                 }
             ],
             "time": "2023-12-11T17:09:12+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -1649,90 +1726,6 @@
             "time": "2026-06-23T13:02:23+00:00"
         },
         {
-            "name": "intervention/image",
-            "version": "2.7.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Intervention/image.git",
-                "reference": "04be355f8d6734c826045d02a1079ad658322dad"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Intervention/image/zipball/04be355f8d6734c826045d02a1079ad658322dad",
-                "reference": "04be355f8d6734c826045d02a1079ad658322dad",
-                "shasum": ""
-            },
-            "require": {
-                "ext-fileinfo": "*",
-                "guzzlehttp/psr7": "~1.1 || ^2.0",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "~0.9.2",
-                "phpunit/phpunit": "^4.8 || ^5.7 || ^7.5.15"
-            },
-            "suggest": {
-                "ext-gd": "to use GD library based image processing.",
-                "ext-imagick": "to use Imagick based image processing.",
-                "intervention/imagecache": "Caching extension for the Intervention Image library"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "aliases": {
-                        "Image": "Intervention\\Image\\Facades\\Image"
-                    },
-                    "providers": [
-                        "Intervention\\Image\\ImageServiceProvider"
-                    ]
-                },
-                "branch-alias": {
-                    "dev-master": "2.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Intervention\\Image\\": "src/Intervention/Image"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Oliver Vogel",
-                    "email": "oliver@intervention.io",
-                    "homepage": "https://intervention.io/"
-                }
-            ],
-            "description": "Image handling and manipulation library with support for Laravel integration",
-            "homepage": "http://image.intervention.io/",
-            "keywords": [
-                "gd",
-                "image",
-                "imagick",
-                "laravel",
-                "thumbnail",
-                "watermark"
-            ],
-            "support": {
-                "issues": "https://github.com/Intervention/image/issues",
-                "source": "https://github.com/Intervention/image/tree/2.7.2"
-            },
-            "funding": [
-                {
-                    "url": "https://paypal.me/interventionio",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/Intervention",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-05-21T17:30:32+00:00"
-        },
-        {
             "name": "jean85/pretty-package-versions",
             "version": "2.1.1",
             "source": {
@@ -2696,71 +2689,6 @@
                 "source": "https://github.com/thephpleague/flysystem-local/tree/3.31.0"
             },
             "time": "2026-01-23T15:30:45+00:00"
-        },
-        {
-            "name": "league/glide",
-            "version": "2.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/glide.git",
-                "reference": "b8e946dd87c79a9dce3290707ab90b5b52602813"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/glide/zipball/b8e946dd87c79a9dce3290707ab90b5b52602813",
-                "reference": "b8e946dd87c79a9dce3290707ab90b5b52602813",
-                "shasum": ""
-            },
-            "require": {
-                "intervention/image": "^2.7",
-                "league/flysystem": "^2.0|^3.0",
-                "php": "^7.2|^8.0",
-                "psr/http-message": "^1.0|^2.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^1.3.3",
-                "phpunit/php-token-stream": "^3.1|^4.0",
-                "phpunit/phpunit": "^8.5|^9.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "League\\Glide\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jonathan Reinink",
-                    "email": "jonathan@reinink.ca",
-                    "homepage": "http://reinink.ca"
-                },
-                {
-                    "name": "Titouan Galopin",
-                    "email": "galopintitouan@gmail.com",
-                    "homepage": "https://titouangalopin.com"
-                }
-            ],
-            "description": "Wonderfully easy on-demand image manipulation library with an HTTP based API.",
-            "homepage": "http://glide.thephpleague.com",
-            "keywords": [
-                "ImageMagick",
-                "editing",
-                "gd",
-                "image",
-                "imagick",
-                "league",
-                "manipulation",
-                "processing"
-            ],
-            "support": {
-                "issues": "https://github.com/thephpleague/glide/issues",
-                "source": "https://github.com/thephpleague/glide/tree/2.3.2"
-            },
-            "time": "2025-03-21T13:48:39+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -4976,33 +4904,39 @@
         },
         {
             "name": "spatie/image",
-            "version": "2.2.7",
+            "version": "3.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/image.git",
-                "reference": "2f802853aab017aa615224daae1588054b5ab20e"
+                "reference": "7ac0b9dab1100ddfc0c98afd12720f5b9fc0cd65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/image/zipball/2f802853aab017aa615224daae1588054b5ab20e",
-                "reference": "2f802853aab017aa615224daae1588054b5ab20e",
+                "url": "https://api.github.com/repos/spatie/image/zipball/7ac0b9dab1100ddfc0c98afd12720f5b9fc0cd65",
+                "reference": "7ac0b9dab1100ddfc0c98afd12720f5b9fc0cd65",
                 "shasum": ""
             },
             "require": {
                 "ext-exif": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "league/glide": "^2.2.2",
-                "php": "^8.0",
-                "spatie/image-optimizer": "^1.7",
-                "spatie/temporary-directory": "^1.0|^2.0",
-                "symfony/process": "^3.0|^4.0|^5.0|^6.0"
+                "php": "^8.2",
+                "spatie/image-optimizer": "^1.7.5",
+                "spatie/temporary-directory": "^2.2",
+                "symfony/process": "^6.4|^7.0|^8.0"
             },
             "require-dev": {
-                "pestphp/pest": "^1.22",
-                "phpunit/phpunit": "^9.5",
-                "symfony/var-dumper": "^4.0|^5.0|^6.0",
-                "vimeo/psalm": "^4.6"
+                "ext-ffi": "*",
+                "ext-gd": "*",
+                "ext-imagick": "*",
+                "jcupitt/vips": "^2.4",
+                "laravel/sail": "^1.34",
+                "pestphp/pest": "^3.0|^4.0",
+                "phpstan/phpstan": "^1.10.50",
+                "spatie/pest-plugin-snapshots": "^2.1",
+                "spatie/pixelmatch-php": "^1.0",
+                "spatie/ray": "^1.40.1",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5029,7 +4963,7 @@
                 "spatie"
             ],
             "support": {
-                "source": "https://github.com/spatie/image/tree/2.2.7"
+                "source": "https://github.com/spatie/image/tree/3.9.5"
             },
             "funding": [
                 {
@@ -5041,7 +4975,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-07-24T13:54:13+00:00"
+            "time": "2026-06-19T07:40:17+00:00"
         },
         {
             "name": "spatie/image-optimizer",
@@ -5199,53 +5133,55 @@
         },
         {
             "name": "spatie/laravel-medialibrary",
-            "version": "10.15.0",
+            "version": "11.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-medialibrary.git",
-                "reference": "f464c82357500c5c68ea350edff35ed9831fd48e"
+                "reference": "143106b61b945f1ca815e6a71598c03881469228"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-medialibrary/zipball/f464c82357500c5c68ea350edff35ed9831fd48e",
-                "reference": "f464c82357500c5c68ea350edff35ed9831fd48e",
+                "url": "https://api.github.com/repos/spatie/laravel-medialibrary/zipball/143106b61b945f1ca815e6a71598c03881469228",
+                "reference": "143106b61b945f1ca815e6a71598c03881469228",
                 "shasum": ""
             },
             "require": {
+                "composer/semver": "^3.4",
                 "ext-exif": "*",
                 "ext-fileinfo": "*",
                 "ext-json": "*",
-                "illuminate/bus": "^9.18|^10.0",
-                "illuminate/conditionable": "^9.18|^10.0",
-                "illuminate/console": "^9.18|^10.0",
-                "illuminate/database": "^9.18|^10.0",
-                "illuminate/pipeline": "^9.18|^10.0",
-                "illuminate/support": "^9.18|^10.0",
-                "maennchen/zipstream-php": "^2.0|^3.0",
-                "php": "^8.0",
-                "spatie/image": "^2.2.7",
-                "spatie/temporary-directory": "^2.0",
-                "symfony/console": "^6.0"
+                "illuminate/bus": "^10.2|^11.0|^12.0|^13.0",
+                "illuminate/conditionable": "^10.2|^11.0|^12.0|^13.0",
+                "illuminate/console": "^10.2|^11.0|^12.0|^13.0",
+                "illuminate/database": "^10.2|^11.0|^12.0|^13.0",
+                "illuminate/pipeline": "^10.2|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.2|^11.0|^12.0|^13.0",
+                "maennchen/zipstream-php": "^3.1",
+                "php": "^8.2",
+                "spatie/image": "^3.3.2",
+                "spatie/laravel-package-tools": "^1.16.1",
+                "spatie/temporary-directory": "^2.2",
+                "symfony/console": "^6.4.1|^7.0|^8.0"
             },
             "conflict": {
                 "php-ffmpeg/php-ffmpeg": "<0.6.1"
             },
             "require-dev": {
-                "aws/aws-sdk-php": "^3.133.11",
-                "doctrine/dbal": "^2.13",
+                "aws/aws-sdk-php": "^3.293.10",
                 "ext-imagick": "*",
                 "ext-pdo_sqlite": "*",
                 "ext-zip": "*",
-                "guzzlehttp/guzzle": "^7.4",
-                "league/flysystem-aws-s3-v3": "^3.0",
-                "mockery/mockery": "^1.4",
-                "nunomaduro/larastan": "^2.0",
-                "orchestra/testbench": "^7.0|^8.0",
-                "pestphp/pest": "^1.21",
-                "phpstan/extension-installer": "^1.1",
-                "spatie/laravel-ray": "^1.28",
-                "spatie/pdf-to-image": "^2.1",
-                "spatie/phpunit-snapshot-assertions": "^4.2"
+                "guzzlehttp/guzzle": "^7.8.1",
+                "larastan/larastan": "^2.7|^3.0",
+                "league/flysystem-aws-s3-v3": "^3.22",
+                "mockery/mockery": "^1.6.7",
+                "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+                "pestphp/pest": "^2.36|^3.0|^4.0",
+                "phpstan/extension-installer": "^1.3.1",
+                "spatie/laravel-ray": "^1.33",
+                "spatie/pdf-to-image": "^2.2|^3.0",
+                "spatie/pest-expectations": "^1.13",
+                "spatie/pest-plugin-snapshots": "^2.1"
             },
             "suggest": {
                 "league/flysystem-aws-s3-v3": "Required to use AWS S3 file storage",
@@ -5291,7 +5227,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-medialibrary/issues",
-                "source": "https://github.com/spatie/laravel-medialibrary/tree/10.15.0"
+                "source": "https://github.com/spatie/laravel-medialibrary/tree/11.23.1"
             },
             "funding": [
                 {
@@ -5303,7 +5239,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-03T13:09:19+00:00"
+            "time": "2026-06-24T08:31:39+00:00"
         },
         {
             "name": "spatie/laravel-package-tools",
@@ -8997,83 +8933,6 @@
                 }
             ],
             "time": "2026-06-07T11:47:49+00:00"
-        },
-        {
-            "name": "composer/semver",
-            "version": "3.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.11",
-                "symfony/phpunit-bridge": "^3 || ^7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "support": {
-                "irc": "ircs://irc.libera.chat:6697/composer",
-                "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.4"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "composer/xdebug-handler",

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -3,111 +3,184 @@
 return [
 
     /*
-    |--------------------------------------------------------------------------
+    |---------------------------------------------------------------------------
     | Class Namespace
-    |--------------------------------------------------------------------------
+    |---------------------------------------------------------------------------
     |
-    | This value sets the root namespace for Livewire component classes in
-    | your application. This value affects component auto-discovery and
-    | any Livewire file helper commands, like `artisan make:livewire`.
-    |
-    | After changing this item, run: `php artisan livewire:discover`.
+    | This value sets the root class namespace for Livewire component classes in
+    | your application. This value will change where component auto-discovery
+    | finds components. It's also referenced by the file creation commands.
     |
     */
 
     'class_namespace' => 'App\\Http\\Livewire',
 
     /*
-    |--------------------------------------------------------------------------
+    |---------------------------------------------------------------------------
     | View Path
-    |--------------------------------------------------------------------------
+    |---------------------------------------------------------------------------
     |
-    | This value sets the path for Livewire component views. This affects
-    | file manipulation helper commands like `artisan make:livewire`.
+    | This value is used to specify where Livewire component Blade templates are
+    | stored when running file creation commands like `artisan make:livewire`.
+    | It is also used if you choose to omit a component's render() method.
     |
     */
 
     'view_path' => resource_path('views/livewire'),
 
     /*
-    |--------------------------------------------------------------------------
+    |---------------------------------------------------------------------------
     | Layout
-    |--------------------------------------------------------------------------
-    | The default layout view that will be used when rendering a component via
-    | Route::get('/some-endpoint', SomeComponent::class);. In this case the
-    | the view returned by SomeComponent will be wrapped in "layouts.app"
+    |---------------------------------------------------------------------------
+    | The view that will be used as the layout when rendering a single component
+    | as an entire page via `Route::get('/post/create', CreatePost::class);`.
+    | In this case, the view returned by CreatePost will render into $slot.
     |
     */
-    
+
     'layout' => 'layouts.app',
 
     /*
-    |--------------------------------------------------------------------------
-    | Livewire Assets URL
-    |--------------------------------------------------------------------------
-    |
-    | This value sets the path to Livewire JavaScript assets, for cases where
-    | your app's domain root is not the correct path. By default, Livewire
-    | will load its JavaScript assets from the app's "relative root".
-    |
-    | Examples: "/assets", "myurl.com/app".
+    |---------------------------------------------------------------------------
+    | Lazy Loading Placeholder
+    |---------------------------------------------------------------------------
+    | Livewire allows you to lazy load components that would otherwise slow down
+    | the initial page load. Every component can have a custom placeholder or
+    | you can define the default placeholder view for all components below.
     |
     */
 
-    'asset_url' => env('APP_URL', null),
+    'lazy_placeholder' => null,
 
     /*
-    |--------------------------------------------------------------------------
-    | Livewire Endpoint Middleware Group
-    |--------------------------------------------------------------------------
-    |
-    | This value sets the middleware group that will be applied to the main
-    | Livewire "message" endpoint (the endpoint that gets hit everytime
-    | a Livewire component updates). It is set to "web" by default.
-    |
-    */
-
-    'middleware_group' => 'web',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Livewire Temporary File Uploads Endpoint Configuration
-    |--------------------------------------------------------------------------
+    |---------------------------------------------------------------------------
+    | Temporary File Uploads
+    |---------------------------------------------------------------------------
     |
     | Livewire handles file uploads by storing uploads in a temporary directory
-    | before the file is validated and stored permanently. All file uploads
-    | are directed to a global endpoint for temporary storage. The config
-    | items below are used for customizing the way the endpoint works.
+    | before the file is stored permanently. All file uploads are directed to
+    | a global endpoint for temporary storage. You may configure this below:
     |
     */
 
     'temporary_file_upload' => [
-        'disk' => null,        // Example: 'local', 's3'              Default: 'default'
-        'rules' => null,       // Example: ['file', 'mimes:png,jpg']  Default: ['required', 'file', 'max:12288'] (12MB)
-        'directory' => null,   // Example: 'tmp'                      Default  'livewire-tmp'
-        'middleware' => null,  // Example: 'throttle:5,1'             Default: 'throttle:60,1'
-        'preview_mimes' => [   // Supported file types for temporary pre-signed file URLs.
+        'disk' => null,        // Example: 'local', 's3'              | Default: 'default'
+        'rules' => null,       // Example: ['file', 'mimes:png,jpg']  | Default: ['required', 'file', 'max:12288'] (12MB)
+        'directory' => null,   // Example: 'tmp'                      | Default: 'livewire-tmp'
+        'middleware' => null,  // Example: 'throttle:5,1'             | Default: 'throttle:60,1'
+        'preview_mimes' => [   // Supported file types for temporary pre-signed file URLs...
             'png', 'gif', 'bmp', 'svg', 'wav', 'mp4',
             'mov', 'avi', 'wmv', 'mp3', 'm4a',
             'jpg', 'jpeg', 'mpga', 'webp', 'wma',
         ],
-        'max_upload_time' => 5, // Max duration (in minutes) before an upload gets invalidated.
+        'max_upload_time' => 5, // Max duration (in minutes) before an upload is invalidated...
+        'cleanup' => true, // Should cleanup temporary uploads older than 24 hrs...
     ],
 
     /*
-    |--------------------------------------------------------------------------
-    | Manifest File Path
-    |--------------------------------------------------------------------------
+    |---------------------------------------------------------------------------
+    | Render On Redirect
+    |---------------------------------------------------------------------------
     |
-    | This value sets the path to the Livewire manifest file.
-    | The default should work for most cases (which is
-    | "<app_root>/bootstrap/cache/livewire-components.php)", but for specific
-    | cases like when hosting on Laravel Vapor, it could be set to a different value.
-    |
-    | Example: for Laravel Vapor, it would be "/tmp/storage/bootstrap/cache/livewire-components.php".
+    | This value determines if Livewire will run a component's `render()` method
+    | after a redirect has been triggered using something like `redirect(...)`
+    | Setting this to true will render the view once more before redirecting
     |
     */
 
-    'manifest_path' => null,
+    'render_on_redirect' => false,
 
+    /*
+    |---------------------------------------------------------------------------
+    | Eloquent Model Binding
+    |---------------------------------------------------------------------------
+    |
+    | Previous versions of Livewire supported binding directly to eloquent model
+    | properties using wire:model by default. However, this behavior has been
+    | deemed too "magical" and has therefore been put under a feature flag.
+    |
+    */
+
+    'legacy_model_binding' => false,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Auto-inject Frontend Assets
+    |---------------------------------------------------------------------------
+    |
+    | By default, Livewire automatically injects its JavaScript and CSS into the
+    | <head> and <body> of pages containing Livewire components. By disabling
+    | this behavior, you need to use @livewireStyles and @livewireScripts.
+    |
+    */
+
+    'inject_assets' => true,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Navigate (SPA mode)
+    |---------------------------------------------------------------------------
+    |
+    | By adding `wire:navigate` to links in your Livewire application, Livewire
+    | will prevent the default link handling and instead request those pages
+    | via AJAX, creating an SPA-like effect. Configure this behavior here.
+    |
+    */
+
+    'navigate' => [
+        'show_progress_bar' => true,
+        'progress_bar_color' => '#2299dd',
+    ],
+
+    /*
+    |---------------------------------------------------------------------------
+    | HTML Morph Markers
+    |---------------------------------------------------------------------------
+    |
+    | Livewire intelligently "morphs" existing HTML into the newly rendered HTML
+    | after each update. To make this process more reliable, Livewire injects
+    | "markers" into the rendered Blade surrounding @if, @class & @foreach.
+    |
+    */
+
+    'inject_morph_markers' => true,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Smart Wire Keys
+    |---------------------------------------------------------------------------
+    |
+    | Livewire uses loops and keys used within loops to generate smart keys that
+    | are applied to nested components that don't have them. This makes using
+    | nested components more reliable by ensuring that they all have keys.
+    |
+    */
+
+    'smart_wire_keys' => false,
+
+    /*
+    |---------------------------------------------------------------------------
+    | Pagination Theme
+    |---------------------------------------------------------------------------
+    |
+    | When enabling Livewire's pagination feature by using the `WithPagination`
+    | trait, Livewire will use Tailwind templates to render pagination views
+    | on the page. If you want Bootstrap CSS, you can specify: "bootstrap"
+    |
+    */
+
+    'pagination_theme' => 'bootstrap',
+
+    /*
+    |---------------------------------------------------------------------------
+    | Release Token
+    |---------------------------------------------------------------------------
+    |
+    | This token is stored client-side and sent along with each request to check
+    | a users session to see if a new release has invalidated it. If there is
+    | a mismatch it will throw an error and prompt for a browser refresh.
+    |
+    */
+
+    'release_token' => 'a',
 ];

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -1,12 +1,51 @@
 <?php
 
+use App\Conversions\Svg;
+// use Spatie\ImageOptimizer\Optimizers\Avifenc;
+use Spatie\ImageOptimizer\Optimizers\Cwebp;
+use Spatie\ImageOptimizer\Optimizers\Gifsicle;
+use Spatie\ImageOptimizer\Optimizers\Jpegoptim;
+use Spatie\ImageOptimizer\Optimizers\Optipng;
+use Spatie\ImageOptimizer\Optimizers\Pngquant;
+use Spatie\ImageOptimizer\Optimizers\Svgo;
+// use Spatie\MediaLibrary\Conversions\ImageGenerators\Avif;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Image;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf;
+// use Spatie\MediaLibrary\Conversions\ImageGenerators\Svg;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Video;
+use Spatie\MediaLibrary\Conversions\ImageGenerators\Webp;
+use Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob;
+use Spatie\MediaLibrary\Downloaders\DefaultDownloader;
+use Spatie\MediaLibrary\MediaCollections\FileAdder;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\MediaCollections\Models\Observers\MediaObserver;
+use Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob;
+use Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred;
+use Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator;
+use Spatie\MediaLibrary\Support\FileNamer\DefaultFileNamer;
+use Spatie\MediaLibrary\Support\FileRemover\DefaultFileRemover;
+use Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator;
+use Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator;
+// use Spatie\MediaLibraryPro\Models\TemporaryUpload;
+
 return [
 
     /*
-     * The filesystems on which to store added files and derived images by default. Choose
-     * one or more of the filesystems you configured in app/config/filesystems.php
+     * The disk on which to store added files and derived images by default. Choose
+     * one or more of the disks you've configured in config/filesystems.php.
      */
-    'disk_name' => 'public_media',
+    'disk_name' => env('MEDIA_DISK', 'public_media'),
+
+    /*
+     * The disk on which to store conversions (thumbnails, etc.) and responsive images
+     * when no disk is specified explicitly on the media collection or via
+     * `storingConversionsOnDisk()`. When left null, conversions are stored on the
+     * same disk as the original media — preserving previous behavior.
+     *
+     * This is useful when the originals live on a remote disk (e.g. S3) but the
+     * generated derivatives should stay local for faster access and lower egress.
+     */
+    'conversions_disk_name' => env('MEDIA_CONVERSIONS_DISK', null),
 
     /*
      * The maximum file size of an item in bytes. Adding a file
@@ -15,10 +54,38 @@ return [
     'max_file_size' => 1024 * 1024 * ((int) env('IMAGE_MAX_MB', 16)),
 
     /*
+     * Uploads whose file name contains any of these extensions will be rejected.
+     * The check looks at every extension in the file name, so a file named
+     * `malicious.php.jpg` is blocked as well. Matching is case-insensitive
+     * and a leading dot is optional.
+     *
+     * The default list lives on the `FileAdder` class so the shipped config
+     * and the in-code fallback (used when the config is cached without the
+     * key) cannot drift. Override here to extend or shrink it.
+     */
+    'disallowed_extensions' => FileAdder::$defaultDisallowedExtensions,
+
+    /*
+     * When this is set to an array of extensions, only uploads whose final
+     * extension is in the list will be accepted. Matching is case-insensitive
+     * and a leading dot is optional. The `disallowed_extensions` list above
+     * is still enforced, so an interior dangerous segment (such as the `php`
+     * in `shell.php.jpg`) is rejected even if the final extension is allowed.
+     * Leave `null` to disable allowlisting.
+     */
+    'allowed_extensions' => null,
+
+    /*
+     * This queue connection will be used to generate derived and responsive images.
+     * Leave empty to use the default queue connection.
+     */
+    'queue_connection_name' => env('QUEUE_CONNECTION', 'sync'),
+
+    /*
      * This queue will be used to generate derived images.
      * Leave empty to use the default queue.
      */
-    'queue_name' => '',
+    'queue_name' => env('MEDIA_QUEUE', ''),
 
     /*
      * By default all conversions will be performed on a queue.
@@ -26,16 +93,29 @@ return [
     'queue_conversions_by_default' => env('QUEUE_CONVERSIONS_BY_DEFAULT', true),
 
     /*
-     * The class name of the media model to be used.
+     * The fully qualified class name of the media model.
      */
-    'media_model' => Spatie\MediaLibrary\MediaCollections\Models\Media::class,
+    'media_model' => Media::class,
+
+    /*
+     * The fully qualified class name of the media observer.
+     */
+    'media_observer' => MediaObserver::class,
+
+    /*
+     * When enabled, media collections will be serialised using the default
+     * laravel model serialization behaviour.
+     *
+     * Keep this option disabled if using Media Library Pro components (https://medialibrary.pro)
+     */
+    'use_default_collection_serialization' => false,
 
     /*
      * The fully qualified class name of the model used for temporary uploads.
      *
      * This model is only used in Media Library Pro (https://medialibrary.pro)
      */
-    'temporary_upload_model' => Spatie\MediaLibraryPro\Models\TemporaryUpload::class,
+    // 'temporary_upload_model' => TemporaryUpload::class,
 
     /*
      * When enabled, Media Library Pro will only process temporary uploads that were uploaded
@@ -52,25 +132,32 @@ return [
     /*
      * This is the class that is responsible for naming generated files.
      */
-    'file_namer' => Spatie\MediaLibrary\Support\FileNamer\DefaultFileNamer::class,
+    'file_namer' => DefaultFileNamer::class,
 
     /*
      * The class that contains the strategy for determining a media file's path.
      */
-    'path_generator' => Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator::class,
+    'path_generator' => DefaultPathGenerator::class,
+
+    /*
+     * The class that contains the strategy for determining how to remove files.
+     */
+    'file_remover_class' => DefaultFileRemover::class,
 
     /*
      * Here you can specify which path generator should be used for the given class.
      */
     'custom_path_generators' => [
         // Model::class => PathGenerator::class
+        // or
+        // 'model_morph_alias' => PathGenerator::class
     ],
 
     /*
      * When urls to files get generated, this class will be called. Use the default
      * if your files are stored locally above the site root or on s3.
      */
-    'url_generator' => Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator::class,
+    'url_generator' => DefaultUrlGenerator::class,
 
     /*
      * Moves media on updating to keep path consistent. Enable it only with a custom
@@ -90,28 +177,28 @@ return [
      * the optimizers that will be used by default.
      */
     'image_optimizers' => [
-        Spatie\ImageOptimizer\Optimizers\Jpegoptim::class => [
+        Jpegoptim::class => [
             '-m85', // set maximum quality to 85%
             '--force', // ensure that progressive generation is always done also if a little bigger
             '--strip-all', // this strips out all text information such as comments and EXIF data
             '--all-progressive', // this will make sure the resulting image is a progressive one
         ],
-        Spatie\ImageOptimizer\Optimizers\Pngquant::class => [
+        Pngquant::class => [
             '--force', // required parameter for this package
         ],
-        Spatie\ImageOptimizer\Optimizers\Optipng::class => [
+        Optipng::class => [
             '-i0', // this will result in a non-interlaced, progressive scanned image
             '-o2', // this set the optimization level to two (multiple IDAT compression trials)
             '-quiet', // required parameter for this package
         ],
-        Spatie\ImageOptimizer\Optimizers\Svgo::class => [
+        Svgo::class => [
             '--disable=cleanupIDs', // disabling because it is known to cause troubles
         ],
-        Spatie\ImageOptimizer\Optimizers\Gifsicle::class => [
+        Gifsicle::class => [
             '-b', // required parameter for this package
             '-O3', // this produces the slowest but best results
         ],
-        Spatie\ImageOptimizer\Optimizers\Cwebp::class => [
+        Cwebp::class => [
             '-m 6', // for the slowest compression method in order to get the best compression.
             '-pass 10', // for maximizing the amount of analysis pass.
             '-mt', // multithreading for some speed improvements.
@@ -123,10 +210,10 @@ return [
      * These generators will be used to create an image of media files.
      */
     'image_generators' => [
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Image::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Webp::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Pdf::class,
-        Spatie\MediaLibrary\Conversions\ImageGenerators\Video::class,
+        Image::class,
+        Webp::class,
+        Pdf::class,
+        Video::class,
         App\Conversions\Svg::class,
     ],
 
@@ -138,7 +225,7 @@ return [
 
     /*
      * The engine that will perform the image conversions.
-     * Should be either `gd` or `imagick`
+     * Should be either `gd` or `imagick` or `vips`.
      */
     'image_driver' => env('IMAGE_DRIVER', 'gd'),
 
@@ -150,14 +237,25 @@ return [
     'ffmpeg_path' => env('FFMPEG_PATH', '/usr/bin/ffmpeg'),
     'ffprobe_path' => env('FFPROBE_PATH', '/usr/bin/ffprobe'),
 
+    /*
+     * The timeout (in seconds) that will be used when generating video
+     * thumbnails via FFMPEG.
+     */
+    'ffmpeg_timeout' => env('FFMPEG_TIMEOUT', 900),
+
+    /*
+     * The number of threads that FFMPEG should use. 0 means that FFMPEG
+     * may decide itself.
+     */
+    'ffmpeg_threads' => env('FFMPEG_THREADS', 0),
 
     /*
      * Here you can override the class names of the jobs used by this package. Make sure
      * your custom jobs extend the ones provided by the package.
      */
     'jobs' => [
-        'perform_conversions' => Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob::class,
-        'generate_responsive_images' => Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob::class,
+        'perform_conversions' => PerformConversionsJob::class,
+        'generate_responsive_images' => GenerateResponsiveImagesJob::class,
     ],
 
     /*
@@ -165,7 +263,20 @@ return [
      * This is particularly useful when the url of the image is behind a firewall and
      * need to add additional flags, possibly using curl.
      */
-    'media_downloader' => Spatie\MediaLibrary\Downloaders\DefaultDownloader::class,
+    'media_downloader' => DefaultDownloader::class,
+
+    /*
+     * When using the addMediaFromUrl method the SSL is verified by default.
+     * This is option disables SSL verification when downloading remote media.
+     * Please note that this is a security risk and should only be false in a local environment.
+     */
+    'media_downloader_ssl' => env('MEDIA_DOWNLOADER_SSL', true),
+
+    /*
+     * The default lifetime in minutes for temporary urls.
+     * This is used when you call the `getLastTemporaryUrl` or `getLastTemporaryUrl` method on a media item.
+     */
+    'temporary_url_default_lifetime' => env('MEDIA_TEMPORARY_URL_DEFAULT_LIFETIME', 5),
 
     'remote' => [
         /*
@@ -189,7 +300,7 @@ return [
          *
          * https://docs.spatie.be/laravel-medialibrary/v9/advanced-usage/generating-responsive-images
          */
-        'width_calculator' => Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator::class,
+        'width_calculator' => FileSizeOptimizedWidthCalculator::class,
 
         /*
          * By default rendering media to a responsive image will add some javascript and a tiny placeholder.
@@ -201,7 +312,7 @@ return [
          * This class will generate the tiny placeholder used for progressive image loading. By default
          * the media library will use a tiny blurred jpg image.
          */
-        'tiny_placeholder_generator' => Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred::class,
+        'tiny_placeholder_generator' => Blurred::class,
     ],
 
     /*
@@ -227,4 +338,10 @@ return [
      * If you set this to `/my-subdir`, all your media will be stored in a `/my-subdir` directory.
      */
     'prefix' => env('MEDIA_PREFIX', ''),
+
+    /*
+     * When forcing lazy loading, media will be loaded even if you don't eager load media and you have
+     * disabled lazy loading globally in the service provider.
+     */
+    'force_lazy_loading' => env('FORCE_MEDIA_LIBRARY_LAZY_LOADING', true),
 ];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,7 @@
   </testsuites>
   <php>
     <env name="APP_ENV" value="testing"/>
+    <server name="APP_ENV" value="testing"/>
     <env name="CACHE_DRIVER" value="array"/>
     <env name="SESSION_DRIVER" value="array"/>
     <env name="QUEUE_DRIVER" value="sync"/>

--- a/psalm-ignore.xml
+++ b/psalm-ignore.xml
@@ -1,106 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
   <file src="app/Exceptions/Handler.php">
-    <ForbiddenCode occurrences="1">
-      <code>shell_exec('git rev-parse --verify HEAD')</code>
+    <ForbiddenCode>
+      <code><![CDATA[shell_exec('git rev-parse --verify HEAD')]]></code>
     </ForbiddenCode>
-    <InvalidDocblock occurrences="1">
-      <code>public function render($request, Throwable $e)</code>
+    <InvalidDocblock>
+      <code><![CDATA[public function render($request, Throwable $e)]]></code>
     </InvalidDocblock>
   </file>
-  <file src="app/Helpers/LdapHelper.php">
-    <InvalidReturnStatement occurrences="1">
-      <code>$user</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>User</code>
-    </InvalidReturnType>
-  </file>
   <file src="app/Http/Controllers/ProfilesController.php">
-    <TypeDoesNotContainType occurrences="2">
-      <code>$existing_profile</code>
-      <code>$existing_profile</code>
-    </TypeDoesNotContainType>
-    <UndefinedMagicMethod occurrences="1">
-      <code>inRandomOrder</code>
-    </UndefinedMagicMethod>
-  </file>
-  <file src="app/Http/Livewire/ProfileStudents.php">
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;students</code>
-    </UndefinedThisPropertyAssignment>
-  </file>
-  <file src="app/Http/Livewire/StudentFeedback.php">
-    <TypeDoesNotContainType occurrences="1">
-      <code>auth()-&gt;user()-&gt;id</code>
+    <InvalidStaticInvocation>
+      <code><![CDATA[Profile::containing($search)]]></code>
+      <code><![CDATA[Profile::public()]]></code>
+      <code><![CDATA[Profile::public()]]></code>
+      <code><![CDATA[Profile::taggedWith($search)]]></code>
+    </InvalidStaticInvocation>
+    <TypeDoesNotContainType>
+      <code><![CDATA[$existing_profile]]></code>
+      <code><![CDATA[$existing_profile]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="app/Http/Middleware/AuthorizeCreateProfile.php">
-    <UndefinedInterfaceMethod occurrences="2">
-      <code>authenticate</code>
-      <code>user</code>
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[authenticate]]></code>
+      <code><![CDATA[user]]></code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="app/Ldap/Handlers/LdapAttributeHandler.php">
-    <UndefinedMagicMethod occurrences="1">
-      <code>exists</code>
-    </UndefinedMagicMethod>
-  </file>
-  <file src="app/Student.php">
-    <InvalidReturnStatement occurrences="3">
-      <code>$this-&gt;hasMany(StudentFeedback::class)-&gt;where('type', 'feedback')</code>
-      <code>$this-&gt;hasOne(StudentData::class)-&gt;where('type', 'research_profile')</code>
-      <code>$this-&gt;hasOne(StudentData::class)-&gt;where('type', 'stats')</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="3">
-      <code>\Illuminate\Database\Eloquent\Relations\HasMany</code>
-      <code>\Illuminate\Database\Eloquent\Relations\HasOne</code>
-      <code>\Illuminate\Database\Eloquent\Relations\HasOne</code>
-    </InvalidReturnType>
-  </file>
-  <file src="app/User.php">
-    <InvalidReturnStatement occurrences="5">
-      <code>$this-&gt;currentDelegates()-&gt;where('gets_reminders', '=', true)</code>
-      <code>$this-&gt;currentDelegators()-&gt;where('gets_reminders', '=', true)</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="5">
-      <code>\Illuminate\Database\Eloquent\Relations\BelongsToMany</code>
-      <code>\Illuminate\Database\Eloquent\Relations\BelongsToMany</code>
-      <code>\Illuminate\Database\Eloquent\Relations\BelongsToMany</code>
-      <code>\Illuminate\Database\Eloquent\Relations\BelongsToMany</code>
-      <code>\Illuminate\Database\Query\Builder</code>
-    </InvalidReturnType>
-  </file>
-  <file src="app/Http/Controllers/ProfilesController.php">
-    <InvalidStaticInvocation occurrences="4">
-      <code>Profile::containing($search)</code>
-      <code>Profile::taggedWith($search)</code>
-      <code>Profile::public()</code>
-      <code>Profile::public()</code>
-    </InvalidStaticInvocation>
-    <TypeDoesNotContainType occurrences="2">
-      <code>$existing_profile</code>
-      <code>$existing_profile</code>
-    </TypeDoesNotContainType>
-  </file>
   <file src="app/Http/Controllers/SchoolsController.php">
-    <InvalidStaticInvocation occurrences="1">
-      <code>Profile::fromSchoolId($school-&gt;id)</code>
+    <InvalidStaticInvocation>
+      <code><![CDATA[Profile::fromSchoolId($school->id)]]></code>
     </InvalidStaticInvocation>
   </file>
   <file src="app/Console/Commands/NotifyProfilesAboutStudents.php">
-    <InvalidStaticInvocation occurrences="1">
-      <code>Profile::StudentsPendingReviewWithSemester($semester)</code>
+    <InvalidStaticInvocation>
+      <code><![CDATA[Profile::StudentsPendingReviewWithSemester($semester)]]></code>
     </InvalidStaticInvocation>
   </file>
   <file src="app/Http/Controllers/Testing/TestingController.php">
-    <InvalidStaticInvocation occurrences="1">
-      <code>Profile::EagerStudentsPendingReviewWithSemester($semester)</code>
+    <InvalidStaticInvocation>
+      <code><![CDATA[Profile::EagerStudentsPendingReviewWithSemester($semester)]]></code>
     </InvalidStaticInvocation>
-  </file>
-  <file src="app/Http/Controllers/ProfilesApiController.php">
-    <UndefinedMagicMethod occurrences="1">
-      <code>Profile::select(Profile::apiAttributes())</code>
-    </UndefinedMagicMethod>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,6 +2,8 @@
 <psalm
     errorLevel="4"
     resolveFromConfigFile="true"
+    findUnusedCode="false"
+    findUnusedBaselineEntry="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
@@ -21,6 +23,7 @@
         <PossiblyFalseArgument errorLevel="suppress" />
         <PossiblyNullArgument errorLevel="suppress" />
         <PossiblyInvalidArgument errorLevel="suppress" />
+        <PossiblyUnusedMethod errorLevel="suppress" />
         <RedundantCondition errorLevel="suppress" />
         <MissingClosureParamType errorLevel="suppress" />
         <NoInterfaceProperties errorLevel="suppress" />

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -762,12 +762,16 @@ if ((typeof Livewire === "undefined" ? "undefined" : _typeof(Livewire)) === 'obj
         profiles.toast(message, type);
       }
     });
-    Livewire.onError(function (status, response) {
-      // show a toast instead of a modal for 403 responses
-      if (status === 403) {
-        profiles.toast('⛔️ Sorry, you are not authorized to do that.', 'danger');
-        return false;
-      }
+    Livewire.hook('request', function (_ref) {
+      var fail = _ref.fail;
+      fail(function (_ref2) {
+        var status = _ref2.status,
+          preventDefault = _ref2.preventDefault;
+        if (status === 403) {
+          preventDefault();
+          profiles.toast('⛔️ Sorry, you are not authorized to do that.', 'danger');
+        }
+      });
     });
   });
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -741,9 +741,10 @@ if ((typeof Trix === "undefined" ? "undefined" : _typeof(Trix)) === 'object') {
 // Livewire global hooks
 if ((typeof Livewire === "undefined" ? "undefined" : _typeof(Livewire)) === 'object') {
   if ((typeof FontAwesomeDom === "undefined" ? "undefined" : _typeof(FontAwesomeDom)) === 'object') {
-    document.addEventListener('DOMContentLoaded', function () {
-      Livewire.hook('message.processed', function () {
-        return FontAwesomeDom.i2svg();
+    Livewire.hook('morphed', function (_ref) {
+      var el = _ref.el;
+      return FontAwesomeDom.i2svg({
+        node: el
       });
     });
   }
@@ -762,11 +763,11 @@ if ((typeof Livewire === "undefined" ? "undefined" : _typeof(Livewire)) === 'obj
         profiles.toast(message, type);
       }
     });
-    Livewire.hook('request', function (_ref) {
-      var fail = _ref.fail;
-      fail(function (_ref2) {
-        var status = _ref2.status,
-          preventDefault = _ref2.preventDefault;
+    Livewire.hook('request', function (_ref2) {
+      var fail = _ref2.fail;
+      fail(function (_ref3) {
+        var status = _ref3.status,
+          preventDefault = _ref3.preventDefault;
         if (status === 403) {
           preventDefault();
           profiles.toast('⛔️ Sorry, you are not authorized to do that.', 'danger');
@@ -816,9 +817,12 @@ try {
 
 _fortawesome_fontawesome_svg_core__WEBPACK_IMPORTED_MODULE_0__.config.autoReplaceSvg = 'nest';
 _fortawesome_fontawesome_svg_core__WEBPACK_IMPORTED_MODULE_0__.library.add(_fortawesome_free_solid_svg_icons__WEBPACK_IMPORTED_MODULE_1__.fas, _fortawesome_free_regular_svg_icons__WEBPACK_IMPORTED_MODULE_2__.far, _fortawesome_free_brands_svg_icons__WEBPACK_IMPORTED_MODULE_3__.fab);
+
 // Kicks off the process of finding <i> tags and replacing with <svg>
-_fortawesome_fontawesome_svg_core__WEBPACK_IMPORTED_MODULE_0__.dom.watch();
 window.FontAwesomeDom = _fortawesome_fontawesome_svg_core__WEBPACK_IMPORTED_MODULE_0__.dom;
+document.addEventListener('DOMContentLoaded', function () {
+  return _fortawesome_fontawesome_svg_core__WEBPACK_IMPORTED_MODULE_0__.dom.i2svg();
+});
 
 // Sortable
 window.Sortable = __webpack_require__(/*! sortablejs/Sortable */ "./node_modules/sortablejs/Sortable.js");

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -747,15 +747,28 @@ if ((typeof Livewire === "undefined" ? "undefined" : _typeof(Livewire)) === 'obj
       });
     });
   }
-  Livewire.on('alert', function (message, type) {
-    return profiles.toast(message, type);
-  });
-  Livewire.onError(function (status, response) {
-    // show a toast instead of a modal for 403 responses
-    if (status === 403) {
-      profiles.toast('⛔️ Sorry, you are not authorized to do that.', 'danger');
-      return false;
-    }
+
+  /**
+   * Livewire 3 Global Event Listener
+   */
+  document.addEventListener('livewire:init', function () {
+    Livewire.on('alert', function (event) {
+      // Livewire 3 passes parameters nested inside an array container
+      // event[0] holds the named object: { message: "...", type: "..." }
+      var eventData = Array.isArray(event) ? event[0] : event;
+      var message = eventData === null || eventData === void 0 ? void 0 : eventData.message;
+      var type = (eventData === null || eventData === void 0 ? void 0 : eventData.type) || 'success';
+      if (message) {
+        profiles.toast(message, type);
+      }
+    });
+    Livewire.onError(function (status, response) {
+      // show a toast instead of a modal for 403 responses
+      if (status === 403) {
+        profiles.toast('⛔️ Sorry, you are not authorized to do that.', 'danger');
+        return false;
+      }
+    });
   });
 }
 

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,6 +1,6 @@
 {
-    "/js/app.js": "/js/app.js?id=d53948d8ce9ce761bd7ca1001d67e004",
-    "/js/app.js.map": "/js/app.js.map?id=271c8f103c569b8f5613b8778d48ee75",
+    "/js/app.js": "/js/app.js?id=6025d6b8f75197e5db4de44fb34acca1",
+    "/js/app.js.map": "/js/app.js.map?id=f77462c6fa9a5b127db576120c7d4ff5",
     "/js/manifest.js": "/js/manifest.js?id=dc9ead3d7857b522d7de22d75063453c",
     "/js/manifest.js.map": "/js/manifest.js.map?id=389e00e7d7680b68d4e1d128ce27ff48",
     "/css/app.css": "/css/app.css?id=0fd161f323dd5c77642c3240bbb47d16",

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,6 +1,6 @@
 {
-    "/js/app.js": "/js/app.js?id=2b7e88b71c1f1d5f42beb73d64e5e63f",
-    "/js/app.js.map": "/js/app.js.map?id=c9f0924715c3f4ed64d9ff0eb259ce52",
+    "/js/app.js": "/js/app.js?id=f6d549e4db922c72d272b2b4ffa298c3",
+    "/js/app.js.map": "/js/app.js.map?id=2244c2d16f5ee84e47ff9d65457a94d1",
     "/js/manifest.js": "/js/manifest.js?id=dc9ead3d7857b522d7de22d75063453c",
     "/js/manifest.js.map": "/js/manifest.js.map?id=389e00e7d7680b68d4e1d128ce27ff48",
     "/css/app.css": "/css/app.css?id=0fd161f323dd5c77642c3240bbb47d16",

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,6 +1,6 @@
 {
-    "/js/app.js": "/js/app.js?id=6025d6b8f75197e5db4de44fb34acca1",
-    "/js/app.js.map": "/js/app.js.map?id=f77462c6fa9a5b127db576120c7d4ff5",
+    "/js/app.js": "/js/app.js?id=2b7e88b71c1f1d5f42beb73d64e5e63f",
+    "/js/app.js.map": "/js/app.js.map?id=c9f0924715c3f4ed64d9ff0eb259ce52",
     "/js/manifest.js": "/js/manifest.js?id=dc9ead3d7857b522d7de22d75063453c",
     "/js/manifest.js.map": "/js/manifest.js.map?id=389e00e7d7680b68d4e1d128ce27ff48",
     "/css/app.css": "/css/app.css?id=0fd161f323dd5c77642c3240bbb47d16",

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -729,12 +729,17 @@ if (typeof Livewire === 'object') {
         });
         
 
-        Livewire.onError((status, response) => {
-            // show a toast instead of a modal for 403 responses
-            if (status === 403) {
-            profiles.toast('⛔️ Sorry, you are not authorized to do that.', 'danger');
-                return false;
-            }
+        Livewire.hook('request', ({ fail }) => {
+            fail(({ status, preventDefault }) => {
+                if (status === 403) {
+                    preventDefault();
+
+                    profiles.toast(
+                        '⛔️ Sorry, you are not authorized to do that.',
+                        'danger'
+                    );
+                }
+            });
         });
     });
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -710,13 +710,32 @@ if (typeof Livewire === 'object') {
       Livewire.hook('message.processed', () => FontAwesomeDom.i2svg());
     });
   }
-  Livewire.on('alert', (message, type) => profiles.toast(message, type));
-  Livewire.onError((status, response) => {
-    // show a toast instead of a modal for 403 responses
-    if (status === 403) {
-      profiles.toast('⛔️ Sorry, you are not authorized to do that.', 'danger');
-        return false;
-    }
-  });
+
+    /**
+     * Livewire 3 Global Event Listener
+     */
+    document.addEventListener('livewire:init', () => {
+        Livewire.on('alert', (event) => {
+            // Livewire 3 passes parameters nested inside an array container
+            // event[0] holds the named object: { message: "...", type: "..." }
+            const eventData = Array.isArray(event) ? event[0] : event;
+
+            const message = eventData?.message;
+            const type = eventData?.type || 'success';
+
+            if (message) {
+                profiles.toast(message, type);
+            }
+        });
+        
+
+        Livewire.onError((status, response) => {
+            // show a toast instead of a modal for 403 responses
+            if (status === 403) {
+            profiles.toast('⛔️ Sorry, you are not authorized to do that.', 'danger');
+                return false;
+            }
+        });
+    });
 }
 

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -705,11 +705,9 @@ if (typeof Trix === 'object') {
 
 // Livewire global hooks
 if (typeof Livewire === 'object') {
-  if (typeof FontAwesomeDom === 'object') {
-    document.addEventListener('DOMContentLoaded', () => {
-      Livewire.hook('message.processed', () => FontAwesomeDom.i2svg());
-    });
-  }
+    if (typeof FontAwesomeDom === 'object') {
+        Livewire.hook('morphed', ({ el }) => FontAwesomeDom.i2svg({ node: el }))
+    }
 
     /**
      * Livewire 3 Global Event Listener

--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -25,9 +25,10 @@ import { fab } from '@fortawesome/free-brands-svg-icons';
 
 config.autoReplaceSvg = 'nest';
 library.add(fas, far, fab);
+
 // Kicks off the process of finding <i> tags and replacing with <svg>
-dom.watch();
 window.FontAwesomeDom = dom;
+document.addEventListener('DOMContentLoaded', () => dom.i2svg());
 
 // Sortable
 window.Sortable = require('sortablejs/Sortable');

--- a/resources/views/livewire/accepting-students-toggle.blade.php
+++ b/resources/views/livewire/accepting-students-toggle.blade.php
@@ -1,7 +1,7 @@
 <form>
     <div class="form-check form-check-inline align-items-baseline m-0">
         <input
-            wire:model="not_accepting_students"
+            wire:model.live="not_accepting_students"
             type="checkbox"
             id="notAcceptingStudentsCheckbox"
             class="form-check-input"

--- a/resources/views/livewire/delegations-table.blade.php
+++ b/resources/views/livewire/delegations-table.blade.php
@@ -3,11 +3,11 @@
     <div class="form-row">
         <div class="form-group col-lg-6">
             <label for="userSearch">Search</label>
-            <input wire:model.debounce.250ms="search_filter" type="text" id="userSearch" class="form-control" placeholder="Search...">
+            <input wire:model.live.debounce.250ms="search_filter" type="text" id="userSearch" class="form-control" placeholder="Search...">
         </div>
         <div class="form-group col-lg-2">
             <label for="delegationNotifyFilter">Notify</label>
-            <select wire:model="notify_filter" id="delegationNotifyFilter" class="form-control">
+            <select wire:model.live="notify_filter" id="delegationNotifyFilter" class="form-control">
                 <option value="" selected>All</option>
                 <option value="1">Yes</option>
                 <option value="0">No</option>
@@ -15,7 +15,7 @@
         </div>
         <div class="form-group col-lg-2">
             <label for="perPage">Per Page</label>
-            <select wire:model="per_page" id="perPage" class="form-control">
+            <select wire:model.live="per_page" id="perPage" class="form-control">
                 <option value="10">10 per page</option>
                 <option value="25" selected>25 per page</option>
                 <option value="50">50 per page</option>

--- a/resources/views/livewire/directory-search.blade.php
+++ b/resources/views/livewire/directory-search.blade.php
@@ -1,7 +1,7 @@
 <div class="directory-search input-group dropdown">
     <input
         id="{{ $input_id }}"
-        wire:model.debounce.250ms="query"
+        wire:model.live.debounce.250ms="query"
         wire:keydown.escape="resetSearch"
         type="text"
         class="form-control position-relative mb-0 dropdown-toggle"
@@ -12,7 +12,7 @@
         @if($aria_describedby) aria-describedby="{{ $aria_describedby }}" @endif
         @if($required) required @endif
     >
-    <input wire:model="selected_username" type="hidden" name="{{ $input_name }}">
+    <input wire:model.live="selected_username" type="hidden" name="{{ $input_name }}">
 
     <div class="dropdown-menu shadow border-primary w-100">
         <button

--- a/resources/views/livewire/profile-data-cards/activities.blade.php
+++ b/resources/views/livewire/profile-data-cards/activities.blade.php
@@ -8,6 +8,6 @@
         </div>
     @endforeach
     @if($paginated)
-        {{ $data->links() }}
+        {{ $data->links(data: ['scrollTo' => '#activities']) }}
     @endif
 </section>

--- a/resources/views/livewire/profile-data-cards/activities.blade.php
+++ b/resources/views/livewire/profile-data-cards/activities.blade.php
@@ -1,13 +1,17 @@
-<section id="activities" class="card">
-    <h3><i class="fas fa-chart-line" aria-hidden="true"></i> Activities @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'activities']) }}" aria-label="Edit Publications"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
-    @foreach($data as $activity)
-        <div class="entry">
-            <h5>{{$activity->title}}</h5>
-            {!! Purify::clean($activity->description) !!}
-            @if($activity->start_date)[{{$activity->start_date}}&ndash;{{$activity->end_date}}] @endif
-        </div>
-    @endforeach
-    @if($paginated)
-        {{ $data->links(data: ['scrollTo' => '#activities']) }}
-    @endif
-</section>
+<div>
+    @unless ($data->isEmpty() && !$editable)
+        <section id="activities" class="card">
+            <h3><i class="fas fa-chart-line" aria-hidden="true"></i> Activities @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'activities']) }}" aria-label="Edit Publications"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+            @foreach($data as $activity)
+                <div class="entry">
+                    <h5>{{$activity->title}}</h5>
+                    {!! Purify::clean($activity->description) !!}
+                    @if($activity->start_date)[{{$activity->start_date}}&ndash;{{$activity->end_date}}] @endif
+                </div>
+            @endforeach
+            @if($paginated)
+                {{ $data->links(data: ['scrollTo' => '#activities']) }}
+            @endif
+        </section>
+    @endunless
+</div>

--- a/resources/views/livewire/profile-data-cards/additionals.blade.php
+++ b/resources/views/livewire/profile-data-cards/additionals.blade.php
@@ -1,12 +1,16 @@
-<section id="additionals" class="card">
-    <h3><i class="fas fa-sticky-note" aria-hidden="true"></i> Additional Information @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'additionals']) }}" aria-label="Edit Additional Information"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
-    @foreach($data as $additional)
-        <div class="entry">
-            <h5><i class="far fa-sticky-note" aria-hidden="true"></i> {{$additional->title}}</h5>
-                {!! Purify::clean($additional->description) !!}
-        </div>
-    @endforeach
-    @if($paginated)
-        {{ $data->links(data: ['scrollTo' => '#additionals']) }}
-    @endif
-</section>
+<div>
+    @unless ($data->isEmpty() && !$editable)
+        <section id="additionals" class="card">
+            <h3><i class="fas fa-sticky-note" aria-hidden="true"></i> Additional Information @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'additionals']) }}" aria-label="Edit Additional Information"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+            @foreach($data as $additional)
+                <div class="entry">
+                    <h5><i class="far fa-sticky-note" aria-hidden="true"></i> {{$additional->title}}</h5>
+                        {!! Purify::clean($additional->description) !!}
+                </div>
+            @endforeach
+            @if($paginated)
+                {{ $data->links(data: ['scrollTo' => '#additionals']) }}
+            @endif
+        </section>
+    @endunless
+</div>

--- a/resources/views/livewire/profile-data-cards/additionals.blade.php
+++ b/resources/views/livewire/profile-data-cards/additionals.blade.php
@@ -7,6 +7,6 @@
         </div>
     @endforeach
     @if($paginated)
-        {{ $data->links() }}
+        {{ $data->links(data: ['scrollTo' => '#additionals']) }}
     @endif
 </section>

--- a/resources/views/livewire/profile-data-cards/affiliations.blade.php
+++ b/resources/views/livewire/profile-data-cards/affiliations.blade.php
@@ -1,13 +1,17 @@
-<section id="affiliations" class="card">
-    <h3><i class="fas fa-users" aria-hidden="true"></i> Affiliations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'affiliations']) }}" aria-label="Edit Affiliations"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
-    @foreach($data as $affiliation)
-        <div class="entry">
-            <h5>{{$affiliation->title}}</h5>
-            @if($affiliation->start_date)<strong>{{$affiliation->start_date}}@if($affiliation->end_date)&ndash;{{$affiliation->end_date}}@endif</strong><br>@endif
-            {!! Purify::clean($affiliation->description) !!}
-        </div>
-    @endforeach
-    @if($paginated)
-        {{ $data->links(data: ['scrollTo' => '#affiliations']) }}
-    @endif
-</section>
+<div>
+    @unless ($data->isEmpty() && !$editable)
+        <section id="affiliations" class="card">
+            <h3><i class="fas fa-users" aria-hidden="true"></i> Affiliations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'affiliations']) }}" aria-label="Edit Affiliations"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+            @foreach($data as $affiliation)
+                <div class="entry">
+                    <h5>{{$affiliation->title}}</h5>
+                    @if($affiliation->start_date)<strong>{{$affiliation->start_date}}@if($affiliation->end_date)&ndash;{{$affiliation->end_date}}@endif</strong><br>@endif
+                    {!! Purify::clean($affiliation->description) !!}
+                </div>
+            @endforeach
+            @if($paginated)
+                {{ $data->links(data: ['scrollTo' => '#affiliations']) }}
+            @endif
+        </section>
+    @endunless
+</div>

--- a/resources/views/livewire/profile-data-cards/affiliations.blade.php
+++ b/resources/views/livewire/profile-data-cards/affiliations.blade.php
@@ -8,6 +8,6 @@
         </div>
     @endforeach
     @if($paginated)
-        {{ $data->links() }}
+        {{ $data->links(data: ['scrollTo' => '#affiliations']) }}
     @endif
 </section>

--- a/resources/views/livewire/profile-data-cards/appointments.blade.php
+++ b/resources/views/livewire/profile-data-cards/appointments.blade.php
@@ -1,16 +1,20 @@
-<section id="appointments" class="card">
-    <h3><i class="fa fa-calendar" aria-hidden="true"></i> Appointments @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'appointments']) }}" aria-label="Edit Appointments"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
-    @foreach($data as $appt)
-        <div class="entry">
-            <strong>{{$appt->appointment}}</strong>
-            <br>
-            <em>{{$appt->organization}}</em> [{{$appt->start_date}}@if($appt->end_date)&ndash;{{$appt->end_date}}@else<span>&ndash;Present</span>@endif]<br />
-            @if($appt->description)
-                {!! Purify::clean($appt->description) !!}
+<div>
+    @unless ($data->isEmpty() && !$editable)
+        <section id="appointments" class="card">
+            <h3><i class="fa fa-calendar" aria-hidden="true"></i> Appointments @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'appointments']) }}" aria-label="Edit Appointments"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+            @foreach($data as $appt)
+                <div class="entry">
+                    <strong>{{$appt->appointment}}</strong>
+                    <br>
+                    <em>{{$appt->organization}}</em> [{{$appt->start_date}}@if($appt->end_date)&ndash;{{$appt->end_date}}@else<span>&ndash;Present</span>@endif]<br />
+                    @if($appt->description)
+                        {!! Purify::clean($appt->description) !!}
+                    @endif
+                </div>
+            @endforeach
+            @if($paginated)
+                {{ $data->links(data: ['scrollTo' => '#appointments']) }}
             @endif
-        </div>
-    @endforeach
-    @if($paginated)
-        {{ $data->links(data: ['scrollTo' => '#appointments']) }}
-    @endif
-</section>
+        </section>
+    @endunless
+</div>

--- a/resources/views/livewire/profile-data-cards/appointments.blade.php
+++ b/resources/views/livewire/profile-data-cards/appointments.blade.php
@@ -11,6 +11,6 @@
         </div>
     @endforeach
     @if($paginated)
-        {{ $data->links() }}
+        {{ $data->links(data: ['scrollTo' => '#appointments']) }}
     @endif
 </section>

--- a/resources/views/livewire/profile-data-cards/areas.blade.php
+++ b/resources/views/livewire/profile-data-cards/areas.blade.php
@@ -1,14 +1,18 @@
-<section id="areas" class="card">
-    <h3><i class="fas fa-flask" aria-hidden="true"></i> Research Areas @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'areas']) }}" aria-label="Edit Research Areas"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
-    @foreach($data as $area)
-        @if($area->url)
-            <h5><a href="{{$area->url}}">{{$area->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h5>
-        @else
-            <h5>{{$area->title}}</h5>
-        @endif
-        {!! Purify::clean($area->description) !!}
-    @endforeach
-    @if($paginated)
-        {{ $data->links(data: ['scrollTo' => '#areas']) }}
-    @endif
-</section>
+<div>
+    @unless ($data->isEmpty() && !$editable)
+        <section id="areas" class="card">
+            <h3><i class="fas fa-flask" aria-hidden="true"></i> Research Areas @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'areas']) }}" aria-label="Edit Research Areas"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+            @foreach($data as $area)
+                @if($area->url)
+                    <h5><a href="{{$area->url}}">{{$area->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h5>
+                @else
+                    <h5>{{$area->title}}</h5>
+                @endif
+                {!! Purify::clean($area->description) !!}
+            @endforeach
+            @if($paginated)
+                {{ $data->links(data: ['scrollTo' => '#areas']) }}
+            @endif
+        </section>
+    @endunless
+</div>

--- a/resources/views/livewire/profile-data-cards/areas.blade.php
+++ b/resources/views/livewire/profile-data-cards/areas.blade.php
@@ -9,6 +9,6 @@
         {!! Purify::clean($area->description) !!}
     @endforeach
     @if($paginated)
-        {{ $data->links() }}
+        {{ $data->links(data: ['scrollTo' => '#areas']) }}
     @endif
 </section>

--- a/resources/views/livewire/profile-data-cards/awards.blade.php
+++ b/resources/views/livewire/profile-data-cards/awards.blade.php
@@ -6,6 +6,6 @@
         </div>
     @endforeach
     @if($paginated)
-        {{ $data->links() }}
+        {{ $data->links(data: ['scrollTo' => '#awards']) }}
     @endif
 </section>

--- a/resources/views/livewire/profile-data-cards/awards.blade.php
+++ b/resources/views/livewire/profile-data-cards/awards.blade.php
@@ -1,11 +1,15 @@
-<section id="awards" class="card">
-    <h3><i class="fa fa-trophy" aria-hidden="true"></i> Awards @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'awards']) }}" aria-label="Edit Awards"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
-    @foreach($data as $award)
-        <div class="entry">
-            <strong>{{$award->name}}</strong> - <em>{{$award->organization}}</em> @if($award->year)[{{$award->year}}]@endif<br />
-        </div>
-    @endforeach
-    @if($paginated)
-        {{ $data->links(data: ['scrollTo' => '#awards']) }}
-    @endif
-</section>
+<div>
+    @unless ($data->isEmpty() && !$editable)
+        <section id="awards" class="card">
+            <h3><i class="fa fa-trophy" aria-hidden="true"></i> Awards @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'awards']) }}" aria-label="Edit Awards"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+            @foreach($data as $award)
+                <div class="entry">
+                    <strong>{{$award->name}}</strong> - <em>{{$award->organization}}</em> @if($award->year)[{{$award->year}}]@endif<br />
+                </div>
+            @endforeach
+            @if($paginated)
+                {{ $data->links(data: ['scrollTo' => '#awards']) }}
+            @endif
+        </section>
+    @endunless
+</div>

--- a/resources/views/livewire/profile-data-cards/news.blade.php
+++ b/resources/views/livewire/profile-data-cards/news.blade.php
@@ -16,6 +16,6 @@
         </div>
     @endforeach
     @if($paginated)
-        {{ $data->links() }}
+        {{ $data->links(data: ['scrollTo' => '#news']) }}
     @endif
 </section>

--- a/resources/views/livewire/profile-data-cards/news.blade.php
+++ b/resources/views/livewire/profile-data-cards/news.blade.php
@@ -1,21 +1,25 @@
-<section id="news" class="card">
-    <h3><i class="fas fa-newspaper" aria-hidden="true"></i> News Articles @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'news']) }}" aria-label="Edit News Articles"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
-    @foreach($data as $article)
-        <div class="entry">
-            @if($article->url)
-                <h5>
-                    <a href="{{$article->url}}" target="_blank" title="link to article">
-                        {{$article->title}} <i class="fas fa-external-link-alt" aria-hidden="true"></i>
-                    </a>
-                </h5>
-            @else
-                <h5>{{$article->title}}</h5>
+<div>
+    @unless ($data->isEmpty() && !$editable)
+        <section id="news" class="card">
+            <h3><i class="fas fa-newspaper" aria-hidden="true"></i> News Articles @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'news']) }}" aria-label="Edit News Articles"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+            @foreach($data as $article)
+                <div class="entry">
+                    @if($article->url)
+                        <h5>
+                            <a href="{{$article->url}}" target="_blank" title="link to article">
+                                {{$article->title}} <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+                            </a>
+                        </h5>
+                    @else
+                        <h5>{{$article->title}}</h5>
+                    @endif
+                    @if($article->image)<img src="{{ $article->imageUrl }}" class="news_image" alt="{{ $article->image_alt ?? $article->title }}"/>@endif
+                    {!! Purify::clean($article->description) !!}
+                </div>
+            @endforeach
+            @if($paginated)
+                {{ $data->links(data: ['scrollTo' => '#news']) }}
             @endif
-            @if($article->image)<img src="{{ $article->imageUrl }}" class="news_image" alt="{{ $article->image_alt ?? $article->title }}"/>@endif
-            {!! Purify::clean($article->description) !!}
-        </div>
-    @endforeach
-    @if($paginated)
-        {{ $data->links(data: ['scrollTo' => '#news']) }}
-    @endif
-</section>
+        </section>
+    @endunless
+</div>

--- a/resources/views/livewire/profile-data-cards/preparation.blade.php
+++ b/resources/views/livewire/profile-data-cards/preparation.blade.php
@@ -8,6 +8,6 @@
         </div>
     @endforeach
     @if($paginated)
-        {{ $data->links() }}
+        {{ $data->links(data: ['scrollTo' => '#preparation']) }}
     @endif
 </section>

--- a/resources/views/livewire/profile-data-cards/preparation.blade.php
+++ b/resources/views/livewire/profile-data-cards/preparation.blade.php
@@ -1,13 +1,17 @@
-<section id="preparation" class="card">
-    <h3><i class="fas fa-graduation-cap" aria-hidden="true"></i> Professional Preparation @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'preparation']) }}" aria-label="Edit Professional Preparation"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
-    @foreach($data as $prep)
-        <div class="entry">
-            {{$prep->degree}} @if($prep->major)- {{$prep->major}}@endif
-            <br>
-            <strong>{{$prep->institution}}</strong>@if($prep->year) - {{$prep->year}}@endif
-        </div>
-    @endforeach
-    @if($paginated)
-        {{ $data->links(data: ['scrollTo' => '#preparation']) }}
-    @endif
-</section>
+<div>
+    @unless ($data->isEmpty() && !$editable)
+        <section id="preparation" class="card">
+            <h3><i class="fas fa-graduation-cap" aria-hidden="true"></i> Professional Preparation @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'preparation']) }}" aria-label="Edit Professional Preparation"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+            @foreach($data as $prep)
+                <div class="entry">
+                    {{$prep->degree}} @if($prep->major)- {{$prep->major}}@endif
+                    <br>
+                    <strong>{{$prep->institution}}</strong>@if($prep->year) - {{$prep->year}}@endif
+                </div>
+            @endforeach
+            @if($paginated)
+                {{ $data->links(data: ['scrollTo' => '#preparation']) }}
+            @endif
+        </section>
+    @endunless
+</div>

--- a/resources/views/livewire/profile-data-cards/presentations.blade.php
+++ b/resources/views/livewire/profile-data-cards/presentations.blade.php
@@ -14,6 +14,6 @@
         </div>
     @endforeach
     @if($paginated)
-        {{ $data->links() }}
+        {{ $data->links(data: ['scrollTo' => '#presentations']) }}
     @endif
 </section>

--- a/resources/views/livewire/profile-data-cards/presentations.blade.php
+++ b/resources/views/livewire/profile-data-cards/presentations.blade.php
@@ -1,19 +1,23 @@
-<section id="presentations" class="card">
-    <h3><i class="fas fa-laptop" aria-hidden="true"></i> Presentations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'presentations']) }}" aria-label="Edit Presentations"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
-    @foreach($data as $presentation)
-        <div class="entry">
-            @if($presentation->url)
-                <h5><a href="{{$presentation->url}}">{{$presentation->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h5>
-            @else
-                <h5>{{$presentation->title}}</h5>
+<div>
+    @unless ($data->isEmpty() && !$editable)
+        <section id="presentations" class="card">
+            <h3><i class="fas fa-laptop" aria-hidden="true"></i> Presentations @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'presentations']) }}" aria-label="Edit Presentations"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+            @foreach($data as $presentation)
+                <div class="entry">
+                    @if($presentation->url)
+                        <h5><a href="{{$presentation->url}}">{{$presentation->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h5>
+                    @else
+                        <h5>{{$presentation->title}}</h5>
+                    @endif
+                    @if($presentation->start_date)<strong>{{$presentation->start_date}}@if($presentation->end_date)&ndash;{{$presentation->end_date}}@endif</strong>@endif
+                    @if($presentation->description)
+                        <em>{!! Purify::clean($presentation->description) !!}</em>
+                    @endif
+                </div>
+            @endforeach
+            @if($paginated)
+                {{ $data->links(data: ['scrollTo' => '#presentations']) }}
             @endif
-            @if($presentation->start_date)<strong>{{$presentation->start_date}}@if($presentation->end_date)&ndash;{{$presentation->end_date}}@endif</strong>@endif
-            @if($presentation->description)
-                <em>{!! Purify::clean($presentation->description) !!}</em>
-            @endif
-        </div>
-    @endforeach
-    @if($paginated)
-        {{ $data->links(data: ['scrollTo' => '#presentations']) }}
-    @endif
-</section>
+        </section>
+    @endunless
+</div>

--- a/resources/views/livewire/profile-data-cards/projects.blade.php
+++ b/resources/views/livewire/profile-data-cards/projects.blade.php
@@ -1,19 +1,23 @@
-<section id="projects" class="card">
-    <h3><i class="fas fa-tasks" aria-hidden="true"></i> Projects @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'projects']) }}" aria-label="Edit Projects"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
-    @foreach($data as $project)
-        <div class="entry">
-            @if($project->url)
-                <h5><a href="{{$project->url}}">{{$project->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h5>
-            @else
-                <h5>{{$project->title}}</h5>
+<div>
+    @unless ($data->isEmpty() && !$editable)
+        <section id="projects" class="card">
+            <h3><i class="fas fa-tasks" aria-hidden="true"></i> Projects @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'projects']) }}" aria-label="Edit Projects"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+            @foreach($data as $project)
+                <div class="entry">
+                    @if($project->url)
+                        <h5><a href="{{$project->url}}">{{$project->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h5>
+                    @else
+                        <h5>{{$project->title}}</h5>
+                    @endif
+                    @if($project->start_date)<strong>{{$project->start_date}}@if($project->end_date)&ndash;{{$project->end_date}}@endif</strong>@endif
+                    @if($project->description)
+                        <em>{!! Purify::clean($project->description) !!}</em>
+                    @endif
+                </div>
+            @endforeach
+            @if($paginated)
+                {{ $data->links(data: ['scrollTo' => '#projects']) }}
             @endif
-            @if($project->start_date)<strong>{{$project->start_date}}@if($project->end_date)&ndash;{{$project->end_date}}@endif</strong>@endif
-            @if($project->description)
-                <em>{!! Purify::clean($project->description) !!}</em>
-            @endif
-        </div>
-    @endforeach
-    @if($paginated)
-        {{ $data->links(data: ['scrollTo' => '#projects']) }}
-    @endif
-</section>
+        </section>
+    @endunless
+</div>

--- a/resources/views/livewire/profile-data-cards/projects.blade.php
+++ b/resources/views/livewire/profile-data-cards/projects.blade.php
@@ -14,6 +14,6 @@
         </div>
     @endforeach
     @if($paginated)
-        {{ $data->links() }}
+        {{ $data->links(data: ['scrollTo' => '#projects']) }}
     @endif
 </section>

--- a/resources/views/livewire/profile-data-cards/publications.blade.php
+++ b/resources/views/livewire/profile-data-cards/publications.blade.php
@@ -21,6 +21,6 @@
         </div>
     @endforeach
     @if($paginated)
-        {{ $data->links() }}
+        {{ $data->links(data: ['scrollTo' => '#publications']) }}
     @endif
 </section>

--- a/resources/views/livewire/profile-data-cards/publications.blade.php
+++ b/resources/views/livewire/profile-data-cards/publications.blade.php
@@ -1,26 +1,30 @@
-<section id="publications" class="card">
-    <h3><i class="fa fa-book" aria-hidden="true"></i> Publications
-        @if($editable)
-        <a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'publications']) }}" data-toggle="class" data-toggle-class="fa-spin" data-target="#publications .fa-sync">
-            @if($profile->hasOrcidManagedPublications())
-                <i class="fas fa-sync"></i> Sync
-            @else
-                <i class="fas fa-edit" aria-label="Edit Publications"></i> Edit
-            @endif
-        </a>
-        @endif
-    </h3>
-    @foreach($data as $pub)
-        <div class="entry">
-            {!! Purify::clean($pub->title) !!} {{$pub->year}} - <strong>{{$pub->type}}</strong>
-            @if($pub->url)
-                <a target="_blank" href="{{$pub->url}}">
-                    <span class="fas fa-external-link-alt" title="external link to publication"></span>
+<div>
+    @unless ($data->isEmpty() && !$editable)
+        <section id="publications" class="card">
+            <h3><i class="fa fa-book" aria-hidden="true"></i> Publications
+                @if($editable)
+                <a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'publications']) }}" data-toggle="class" data-toggle-class="fa-spin" data-target="#publications .fa-sync">
+                    @if($profile->hasOrcidManagedPublications())
+                        <i class="fas fa-sync"></i> Sync
+                    @else
+                        <i class="fas fa-edit" aria-label="Edit Publications"></i> Edit
+                    @endif
                 </a>
+                @endif
+            </h3>
+            @foreach($data as $pub)
+                <div class="entry">
+                    {!! Purify::clean($pub->title) !!} {{$pub->year}} - <strong>{{$pub->type}}</strong>
+                    @if($pub->url)
+                        <a target="_blank" href="{{$pub->url}}">
+                            <span class="fas fa-external-link-alt" title="external link to publication"></span>
+                        </a>
+                    @endif
+                </div>
+            @endforeach
+            @if($paginated)
+                {{ $data->links(data: ['scrollTo' => '#publications']) }}
             @endif
-        </div>
-    @endforeach
-    @if($paginated)
-        {{ $data->links(data: ['scrollTo' => '#publications']) }}
-    @endif
-</section>
+        </section>
+    @endunless
+</div>

--- a/resources/views/livewire/profile-data-cards/support.blade.php
+++ b/resources/views/livewire/profile-data-cards/support.blade.php
@@ -12,6 +12,6 @@
         </div>
     @endforeach
     @if($paginated)
-        {{ $data->links() }}
+        {{ $data->links(data: ['scrollTo' => '#funding']) }}
     @endif
 </section>

--- a/resources/views/livewire/profile-data-cards/support.blade.php
+++ b/resources/views/livewire/profile-data-cards/support.blade.php
@@ -1,17 +1,21 @@
-<section id="funding" class="card">
-    <h3><i class="fas fa-dollar-sign" aria-hidden="true"></i> Funding @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'support']) }}" aria-label="Edit Funding"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
-    @foreach($data as $funding)
-        <div class="entry">
-            @if($funding->url)
-                <h5><a href="{{$funding->url}}">{{$funding->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h5>
-            @else
-                <h5>{{$funding->title}}</h5>
+<div>
+    @unless ($data->isEmpty() && !$editable)
+        <section id="funding" class="card">
+            <h3><i class="fas fa-dollar-sign" aria-hidden="true"></i> Funding @if($editable)<a class="btn btn-primary btn-sm" href="{{ route('profiles.edit', [$profile->slug, 'support']) }}" aria-label="Edit Funding"><i class="fas fa-edit"></i> Edit</a>@endif</h3>
+            @foreach($data as $funding)
+                <div class="entry">
+                    @if($funding->url)
+                        <h5><a href="{{$funding->url}}">{{$funding->title}} <i class="fas fa-link" aria-hidden="true"></i></a></h5>
+                    @else
+                        <h5>{{$funding->title}}</h5>
+                    @endif
+                    <h6>{{$funding->amount}} - {{$funding->sponsor}} [{{$funding->start_date}}@if($funding->end_date)&ndash;{{$funding->end_date}}@endif]</h6>
+                    {{ $funding->description }}
+                </div>
+            @endforeach
+            @if($paginated)
+                {{ $data->links(data: ['scrollTo' => '#funding']) }}
             @endif
-            <h6>{{$funding->amount}} - {{$funding->sponsor}} [{{$funding->start_date}}@if($funding->end_date)&ndash;{{$funding->end_date}}@endif]</h6>
-            {{ $funding->description }}
-        </div>
-    @endforeach
-    @if($paginated)
-        {{ $data->links(data: ['scrollTo' => '#funding']) }}
-    @endif
-</section>
+        </section>
+    @endunless
+</div>

--- a/resources/views/livewire/profile-students.blade.php
+++ b/resources/views/livewire/profile-students.blade.php
@@ -54,11 +54,11 @@
                         <div class="card-body">
                             <div class="form-group">
                                 <label for="studentNameSearch">Name</label>
-                                <input wire:model.debounce.250ms="search_filter" type="text" id="studentNameSearch" class="form-control" placeholder="Search..." autocomplete="name">
+                                <input wire:model.live.debounce.250ms="search_filter" type="text" id="studentNameSearch" class="form-control" placeholder="Search..." autocomplete="name">
                             </div>
                             <div class="form-group">
                                 <label for="studentSemesterSearch">Semester</label>
-                                <select wire:model="semester_filter" id="studentSemesterSearch" class="form-control">
+                                <select wire:model.live="semester_filter" id="studentSemesterSearch" class="form-control">
                                     <option value="" selected>All</option>
                                     @foreach($semesters as $semester)
                                     <option value="{{ $semester }}">{{ $semester }}</option>
@@ -67,7 +67,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="studentTagSearch">Topic Interests</label>
-                                <select wire:model="tag_filter" id="studentTagSearch" class="form-control">
+                                <select wire:model.live="tag_filter" id="studentTagSearch" class="form-control">
                                     <option value="" selected>All</option>
                                     @foreach($tags as $tag)
                                     <option value="{{ $tag->slug }}">{{ $tag->name }}</option>
@@ -76,7 +76,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="studentSchoolSearch">School</label>
-                                <select wire:model="schools_filter" id="studentSchoolSearch" class="form-control">
+                                <select wire:model.live="schools_filter" id="studentSchoolSearch" class="form-control">
                                     <option value="" selected>All</option>
                                     @foreach($schools as $school)
                                     <option value="{{ $school }}">{{ $school }}</option>
@@ -85,7 +85,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="studentMajorSearch">Major</label>
-                                <select wire:model="major_filter" id="studentMajorSearch" class="form-control">
+                                <select wire:model.live="major_filter" id="studentMajorSearch" class="form-control">
                                     <option value="" selected>All</option>
                                     @foreach($majors as $major)
                                     <option value="{{ $major }}">{{ $major }}</option>
@@ -94,7 +94,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="studentLanguageSearch">Language</label>
-                                <select wire:model="language_filter" id="studentLanguageSearch" class="form-control">
+                                <select wire:model.live="language_filter" id="studentLanguageSearch" class="form-control">
                                     <option value="" selected>All</option>
                                     @foreach($languages as $language_code => $language)
                                     <option value="{{ $language_code }}">{{ $language }}</option>
@@ -103,7 +103,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="studentTravelSearch">Travel to Research Centers</label>
-                                <select wire:model="travel_filter" id="studentTravelSearch" class="form-control">
+                                <select wire:model.live="travel_filter" id="studentTravelSearch" class="form-control">
                                     <option value="" selected>All</option>
                                     <option value="1">Yes</option>
                                     <option value="0">No</option>
@@ -111,7 +111,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="studentTravelOtherSearch">Travel to Sites</label>
-                                <select wire:model="travel_other_filter" id="studentTravelOtherSearch" class="form-control">
+                                <select wire:model.live="travel_other_filter" id="studentTravelOtherSearch" class="form-control">
                                     <option value="" selected>All</option>
                                     <option value="1">Yes</option>
                                     <option value="0">No</option>
@@ -119,7 +119,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="studentAnimalsSearch">Work with Animals</label>
-                                <select wire:model="animals_filter" id="studentAnimalsSearch" class="form-control">
+                                <select wire:model.live="animals_filter" id="studentAnimalsSearch" class="form-control">
                                     <option value="" selected>All</option>
                                     <option value="1">Yes</option>
                                     <option value="0">No</option>
@@ -127,7 +127,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="studentCreditSearch">Research Credit</label>
-                                <select wire:model="credit_filter" id="studentCreditSearch" class="form-control">
+                                <select wire:model.live="credit_filter" id="studentCreditSearch" class="form-control">
                                     <option value="" selected>All</option>
                                     <option value="1">Credit</option>
                                     <option value="0">Volunteer</option>
@@ -136,7 +136,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="studentGraduatesSearch">Expected Graduation</label>
-                                <select wire:model="graduation_filter" id="studentGraduatesSearch" class="form-control">
+                                <select wire:model.live="graduation_filter" id="studentGraduatesSearch" class="form-control">
                                     <option value="" selected>All</option>
                                     @foreach($graduation_dates as $graduation_date)
                                     <option value="{{ $graduation_date }}">{{ $graduation_date }}</option>

--- a/resources/views/livewire/profile-students.blade.php
+++ b/resources/views/livewire/profile-students.blade.php
@@ -211,7 +211,7 @@
                                             </a>
                                         </div>
                                         <div>
-                                            <livewire:student-filer :profile="$profile" :student="$student" :status="$student->application->status" :wire:key="$student->slug . '_filer'">
+                                            <livewire:student-filer :profile="$profile" :student="$student" :status="$student->application->status" :key="$student->slug . '_filer_' . $student->application->status" />
                                         </div>
                                     </div>
                                 </div>

--- a/resources/views/livewire/profiles-table.blade.php
+++ b/resources/views/livewire/profiles-table.blade.php
@@ -3,11 +3,11 @@
     <div class="form-row">
         <div class="form-group col-lg-2">
             <label for="profileSearch">Search</label>
-            <input wire:model.debounce.250ms="search_filter" type="text" id="profileSearch" class="form-control" placeholder="Search...">
+            <input wire:model.live.debounce.250ms="search_filter" type="text" id="profileSearch" class="form-control" placeholder="Search...">
         </div>
         <div class="form-group col-lg-2">
             <label for="profileSchoolFilter">School</label>
-            <select wire:model="schools_filter" id="profileSchoolFilter" class="form-control">
+            <select wire:model.live="schools_filter" id="profileSchoolFilter" class="form-control">
                 <option value="" selected>All</option>
                 @foreach($schools as $school)
                 <option value="{{ $school->id }}">{{ $school->short_name }}</option>
@@ -16,7 +16,7 @@
         </div>
         <div class="form-group col-lg-2">
             <label for="publicFilter">Public</label>
-            <select wire:model="public_filter" id="publicFilter" class="form-control">
+            <select wire:model.live="public_filter" id="publicFilter" class="form-control">
                 <option value="" selected>All</option>
                 <option value="1">Public</option>
                 <option value="0">Not Public</option>
@@ -24,7 +24,7 @@
         </div>
         <div class="form-group col-lg-2">
             <label for="typeFilter">Type</label>
-            <select wire:model="type_filter" id="typeFilter" class="form-control">
+            <select wire:model.live="type_filter" id="typeFilter" class="form-control">
                 <option value="" selected>All</option>
                 @foreach (App\Enums\ProfileType::cases() as $profile_type)
                     <option value="{{ $profile_type->value }}">{{ $profile_type->label() }}</option>
@@ -33,14 +33,14 @@
         </div>
         <div class="form-group col-lg-1">
             <label for="archivedFilter">Archived</label>
-            <select wire:model="archived_filter" id="archivedFilter" class="form-control">
+            <select wire:model.live="archived_filter" id="archivedFilter" class="form-control">
                 <option value="0" selected>No</option>
                 <option value="1">Yes</option>
             </select>
         </div>
         <div class="form-group col-lg-1">
             <label for="perPage">Per Page</label>
-            <select wire:model="per_page" id="perPage" class="form-control">
+            <select wire:model.live="per_page" id="perPage" class="form-control">
                 <option value="10">10</option>
                 <option value="25" selected>25</option>
                 <option value="50">50</option>

--- a/resources/views/livewire/student-feedback.blade.php
+++ b/resources/views/livewire/student-feedback.blade.php
@@ -15,7 +15,7 @@
                             <label class="form-label">Select any that apply:</label>
                             @foreach ($reasons as $reason_key => $reason_label)
                                 <div class="form-check">
-                                    <input wire:model.defer="new_feedback.reasons.{{ $reason_key }}" type="checkbox" name="student_{{ $student->id }}_feedback[reasons][{{ $reason_key }}]" id="student_{{ $student->id }}_feedback[reasons][{{ $reason_key }}]">
+                                    <input wire:model="new_feedback.reasons.{{ $reason_key }}" type="checkbox" name="student_{{ $student->id }}_feedback[reasons][{{ $reason_key }}]" id="student_{{ $student->id }}_feedback[reasons][{{ $reason_key }}]">
                                     <label for="student_{{ $student->id }}_feedback[reasons][{{ $reason_key }}]" class="form-check-label">
                                         {{ $reason_label }}
                                     </label>
@@ -25,7 +25,7 @@
 
                         <div class="form-group">
                             <label for="student_{{ $student->id }}_feedback[comment]" class="form-label">Other / Comments:</label>
-                            <textarea wire:model.defer="new_feedback.comment" name="student_{{ $student->id }}_feedback[comment]" id="student_{{ $student->id }}_feedback[comment]" rows="10" class="form-control"></textarea>
+                            <textarea wire:model="new_feedback.comment" name="student_{{ $student->id }}_feedback[comment]" id="student_{{ $student->id }}_feedback[comment]" rows="10" class="form-control"></textarea>
                         </div>
                         <button wire:click="add()" type="button" class="btn btn-primary edit-button" data-toggle="collapse" data-target="#student_{{ $student->id }}_feedback_form" aria-expanded="false" aria-controls="student_{{ $student->id }}_feedback_form">
                             <i class="fas fa-comment-medical"></i> Submit my feedback

--- a/resources/views/livewire/students-table.blade.php
+++ b/resources/views/livewire/students-table.blade.php
@@ -28,11 +28,11 @@
                     <div class="form-row">
                         <div class="form-group col-lg-2">
                             <label for="studentNameSearch">Name</label>
-                            <input wire:model.debounce.250ms="search_filter" type="text" id="studentNameSearch" class="form-control" placeholder="Search...">
+                            <input wire:model.live.debounce.250ms="search_filter" type="text" id="studentNameSearch" class="form-control" placeholder="Search...">
                         </div>
                         <div class="form-group col-lg-2">
                             <label for="studentTagSearch">Topic Interests</label>
-                            <select wire:model="tag_filter" id="studentTagSearch" class="form-control">
+                            <select wire:model.live="tag_filter" id="studentTagSearch" class="form-control">
                                 <option value="" selected>All</option>
                                 @foreach($tags as $tag)
                                 <option value="{{ $tag->slug }}">{{ $tag->name }}</option>
@@ -41,7 +41,7 @@
                         </div>
                         <div class="form-group col-lg-2">
                             <label for="studentFacultySearch">Faculty Interest</label>
-                            <select wire:model="faculty_filter" id="studentFacultySearch" class="form-control">
+                            <select wire:model.live="faculty_filter" id="studentFacultySearch" class="form-control">
                                 <option value="" selected>All</option>
                                 @foreach($faculty as $faculty_id => $faculty_name)
                                 <option value="{{ $faculty_id }}">{{ $faculty_name }}</option>
@@ -50,7 +50,7 @@
                         </div>
                         <div class="form-group col-lg-2">
                             <label for="studentSchoolSearch">School</label>
-                            <select wire:model="schools_filter" id="studentSchoolSearch" class="form-control">
+                            <select wire:model.live="schools_filter" id="studentSchoolSearch" class="form-control">
                                 <option value="" selected>All</option>
                                 @foreach($schools as $school)
                                 <option value="{{ $school }}">{{ $school }}</option>
@@ -59,7 +59,7 @@
                         </div>
                         <div class="form-group col-lg-2">
                             <label for="studentSemesterSearch">Semester</label>
-                            <select wire:model="semester_filter" id="studentSemesterSearch" class="form-control">
+                            <select wire:model.live="semester_filter" id="studentSemesterSearch" class="form-control">
                                 <option value="" selected>All</option>
                                 @foreach($semesters as $semester)
                                 <option value="{{ $semester }}">{{ $semester }}</option>
@@ -68,7 +68,7 @@
                         </div>
                         <div class="form-group col-lg-2">
                             <label for="studentMajorSearch">Major</label>
-                            <select wire:model="major_filter" id="studentMajorSearch" class="form-control">
+                            <select wire:model.live="major_filter" id="studentMajorSearch" class="form-control">
                                 <option value="" selected>All</option>
                                 @foreach($majors as $major)
                                 <option value="{{ $major }}">{{ $major }}</option>
@@ -77,7 +77,7 @@
                         </div>
                         <div class="form-group col-lg-2">
                             <label for="studentLanguageSearch">Language</label>
-                            <select wire:model="language_filter" id="studentLanguageSearch" class="form-control">
+                            <select wire:model.live="language_filter" id="studentLanguageSearch" class="form-control">
                                 <option value="" selected>All</option>
                                 @foreach($languages as $language_code => $language)
                                 <option value="{{ $language_code }}">{{ $language }}</option>
@@ -86,7 +86,7 @@
                         </div>
                         <div class="form-group col-lg-2">
                             <label for="studentTravelSearch">Travel to Centers</label>
-                            <select wire:model="travel_filter" id="studentTravelSearch" class="form-control">
+                            <select wire:model.live="travel_filter" id="studentTravelSearch" class="form-control">
                                 <option value="" selected>All</option>
                                 <option value="1">Yes</option>
                                 <option value="0">No</option>
@@ -94,7 +94,7 @@
                         </div>
                         <div class="form-group col-lg-2">
                             <label for="studentTravelOtherSearch">Travel to Sites</label>
-                            <select wire:model="travel_other_filter" id="studentTravelOtherSearch" class="form-control">
+                            <select wire:model.live="travel_other_filter" id="studentTravelOtherSearch" class="form-control">
                                 <option value="" selected>All</option>
                                 <option value="1">Yes</option>
                                 <option value="0">No</option>
@@ -102,7 +102,7 @@
                         </div>
                         <div class="form-group col-lg-2">
                             <label for="studentAnimalsSearch">Work with Animals</label>
-                            <select wire:model="animals_filter" id="studentAnimalsSearch" class="form-control">
+                            <select wire:model.live="animals_filter" id="studentAnimalsSearch" class="form-control">
                                 <option value="" selected>All</option>
                                 <option value="1">Yes</option>
                                 <option value="0">No</option>
@@ -110,7 +110,7 @@
                         </div>
                         <div class="form-group col-lg-2">
                             <label for="studentCreditSearch">Research Credit</label>
-                            <select wire:model="credit_filter" id="studentCreditSearch" class="form-control">
+                            <select wire:model.live="credit_filter" id="studentCreditSearch" class="form-control">
                                 <option value="" selected>All</option>
                                 <option value="1">Credit</option>
                                 <option value="0">Volunteer</option>
@@ -119,7 +119,7 @@
                         </div>
                         <div class="form-group col-lg-2">
                             <label for="studentGraduatesSearch">Expected Graduation</label>
-                            <select wire:model="graduation_filter" id="studentGraduatesSearch" class="form-control">
+                            <select wire:model.live="graduation_filter" id="studentGraduatesSearch" class="form-control">
                                 <option value="" selected>All</option>
                                 @foreach($graduation_dates as $graduation_date)
                                 <option value="{{ $graduation_date }}">{{ $graduation_date }}</option>
@@ -128,7 +128,7 @@
                         </div>
                         <div class="form-group col-lg-2">
                             <label for="studentStatus">Status</label>
-                            <select wire:model="status_filter" id="studentStatus" class="form-control">
+                            <select wire:model.live="status_filter" id="studentStatus" class="form-control">
                                 <option value="" selected>All</option>
                                 <option value="submitted">submitted</option>
                                 <option value="drafted">drafted</option>
@@ -203,7 +203,7 @@
             {{ $this->students->links() }}
         </div>
         <div class="col-lg-2">
-            <select wire:model="per_page" id="perPage" class="form-control form-control-sm">
+            <select wire:model.live="per_page" id="perPage" class="form-control form-control-sm">
                 <option value="10">10 per page</option>
                 <option value="25" selected>25 per page</option>
                 <option value="50">50 per page</option>

--- a/resources/views/livewire/tags-table.blade.php
+++ b/resources/views/livewire/tags-table.blade.php
@@ -3,11 +3,11 @@
     <div class="form-row">
         <div class="form-group col-lg-6">
             <label for="tagNameSearch">Tag Name</label>
-            <input wire:model.debounce.250ms="search_filter" type="text" id="studentNameSearch" class="form-control" placeholder="Search...">
+            <input wire:model.live.debounce.250ms="search_filter" type="text" id="studentNameSearch" class="form-control" placeholder="Search...">
         </div>
         <div class="form-group col-lg-2">
             <label for="tagTypeFilter">Tag Type</label>
-            <select wire:model="tag_type_filter" id="tagTypeFilter" class="form-control">
+            <select wire:model.live="tag_type_filter" id="tagTypeFilter" class="form-control">
                 <option value="" selected>All</option>
                 @foreach($tag_types as $tag_type)
                 <option value="{{ $tag_type }}">{{ $tag_type }}</option>
@@ -16,7 +16,7 @@
         </div>
         <div class="form-group col-lg-2">
             <label for="perPage">Per Page</label>
-            <select wire:model="per_page" id="perPage" class="form-control">
+            <select wire:model.live="per_page" id="perPage" class="form-control">
                 <option value="10">10</option>
                 <option value="25" selected>25</option>
                 <option value="50">50</option>

--- a/resources/views/livewire/user-delegations.blade.php
+++ b/resources/views/livewire/user-delegations.blade.php
@@ -40,7 +40,7 @@
         </button>
         <div id="user_{{ $user->id }}_delegation_form" class="collapse" wire:ignore.self>
             <div class="card">
-                <form wire:submit.prevent="add()" class="card-body" novalidate>
+                <form wire:submit="add()" class="card-body" novalidate>
                     <div class="form-row">
                         <div class="form-group col-md-6">
                             <label for="user_{{ $user->id }}_directorySearch" class="form-label">Name:</label>
@@ -58,7 +58,7 @@
                             <label for="user_{{ $user->id }}_delegation[name]" class="form-label">Username:</label>
                             <input
                                 type="text"
-                                wire:model="new_delegation.name"
+                                wire:model.live="new_delegation.name"
                                 name="user_{{ $user->id }}_delegation[name]"
                                 id="user_{{ $user->id }}_delegation[name]"
                                 class="form-control mb-0"
@@ -76,7 +76,7 @@
                             <label for="user_{{ $user->id }}_delegation[starting]" class="form-label">Starting:</label>
                             <input
                                 type="text"
-                                wire:model.defer="new_delegation.starting"
+                                wire:model="new_delegation.starting"
                                 name="user_{{ $user->id }}_delegation[starting]"
                                 id="user_{{ $user->id }}_delegation[starting]"
                                 class="form-control mb-0"
@@ -94,7 +94,7 @@
                             <label for="user_{{ $user->id }}_delegation[until]" class="form-label">Until:</label>
                             <input
                                 type="text"
-                                wire:model.defer="new_delegation.until"
+                                wire:model="new_delegation.until"
                                 name="user_{{ $user->id }}_delegation[until]"
                                 id="user_{{ $user->id }}_delegation[until]"
                                 class="form-control mb-0"
@@ -113,7 +113,7 @@
                             <label for="user_{{ $user->id }}_delegation[gets_reminders]" class="form-label clickable">Delegate receives user's notifications:</label>
                             <input
                                 type="checkbox"
-                                wire:model.defer="new_delegation.gets_reminders"
+                                wire:model="new_delegation.gets_reminders"
                                 name="user_{{ $user->id }}_delegation[gets_reminders]"
                                 id="user_{{ $user->id }}_delegation[gets_reminders]"
                                 class="form-check-input clickable"

--- a/resources/views/livewire/users-table.blade.php
+++ b/resources/views/livewire/users-table.blade.php
@@ -3,11 +3,11 @@
     <div class="form-row">
         <div class="form-group col-lg-2">
             <label for="userSearch">Search</label>
-            <input wire:model.debounce.250ms="search_filter" type="text" id="userSearch" class="form-control" placeholder="Search...">
+            <input wire:model.live.debounce.250ms="search_filter" type="text" id="userSearch" class="form-control" placeholder="Search...">
         </div>
         <div class="form-group col-lg-2">
             <label for="userTitleSearch">Title</label>
-            <select wire:model="title_filter" id="userTitleSearch" class="form-control">
+            <select wire:model.live="title_filter" id="userTitleSearch" class="form-control">
                 <option value="" selected>All</option>
                 @foreach($titles as $title)
                 <option value="{{ $title }}">{{ $title }}</option>
@@ -16,7 +16,7 @@
         </div>
         <div class="form-group col-lg-2">
             <label for="userSchoolSearch">School</label>
-            <select wire:model="schools_filter" id="userSchoolSearch" class="form-control">
+            <select wire:model.live="schools_filter" id="userSchoolSearch" class="form-control">
                 <option value="" selected>All</option>
                 @foreach($schools as $school)
                 <option value="{{ $school->id }}">{{ $school->short_name }}</option>
@@ -25,7 +25,7 @@
         </div>
         <div class="form-group col-lg-2">
             <label for="userDepartmentSearch">Department</label>
-            <select wire:model="department_filter" id="userDepartmentSearch" class="form-control">
+            <select wire:model.live="department_filter" id="userDepartmentSearch" class="form-control">
                 <option value="" selected>All</option>
                 @foreach($departments as $department)
                 <option value="{{ $department }}">{{ $department }}</option>
@@ -34,7 +34,7 @@
         </div>
         <div class="form-group col-lg-2">
             <label for="perPage">Per Page</label>
-            <select wire:model="per_page" id="perPage" class="form-control">
+            <select wire:model.live="per_page" id="perPage" class="form-control">
                 <option value="10">10 per page</option>
                 <option value="25" selected>25 per page</option>
                 <option value="50">50 per page</option>

--- a/resources/views/students/edit.blade.php
+++ b/resources/views/students/edit.blade.php
@@ -53,7 +53,7 @@
 
 @push('scripts')
 <script>
-    document.addEventListener('livewire:load', function () {
+    document.addEventListener('livewire:init', function () {
         $("input[type=checkbox][id^=data_school]").on('change', function() {
             if ($(this).is(':checked')) {
                 Livewire.emit('addTagType', "App\\Student\\"+$(this).val());

--- a/resources/views/students/edit.blade.php
+++ b/resources/views/students/edit.blade.php
@@ -53,14 +53,11 @@
 
 @push('scripts')
 <script>
-    document.addEventListener('livewire:init', function () {
-        $("input[type=checkbox][id^=data_school]").on('change', function() {
-            if ($(this).is(':checked')) {
-                Livewire.emit('addTagType', "App\\Student\\"+$(this).val());
-            } else {
-                Livewire.emit('removeTagType', "App\\Student\\"+$(this).val());
-            }
-        })
+    document.addEventListener('livewire:init', () => {
+        $(document).on('change', 'input[type=checkbox][id^=data_school]', function () {
+            const event = this.checked ? 'addTagType' : 'removeTagType';
+            Livewire.dispatch(event, { tag_type: 'App\\Student\\' + this.value });
+        });
     });
 </script>
 @endpush

--- a/tests/Feature/Livewire/ProfileDataCardTest.php
+++ b/tests/Feature/Livewire/ProfileDataCardTest.php
@@ -64,10 +64,16 @@ class ProfileDataCardTest extends TestCase
             $this->assertIsIterable($section_data);
             $this->assertGreaterThanOrEqual($per_page, $data_count);
 
-            $component = Livewire::test(ProfileDataCard::class, ['profile' => $profile, 'editable' => $editable, 'data_type' => $section ])
-                        ->assertSet('data_type', $section)
-                        ->assertViewHas('data')
-                        ->assertSeeHtmlInOrder(["<section id=\"$section\" class=\"card\">", '<h3>', '<div class="entry">'] );
+            $component = Livewire::test(ProfileDataCard::class, ['profile' => $profile, 'editable' => $editable, 'data_type' => $section])
+                            ->assertSet('data_type', $section)
+                            ->assertViewHas('data')
+                            ->assertSeeHtmlInOrder([
+                                '<section',
+                                "id=\"$section\"",
+                                'class="card"',
+                                '<h3>',
+                                '<div class="entry">',
+                            ]);
 
             if ($section === 'additionals') {
                 $component->assertSee('Additional Information');
@@ -76,17 +82,19 @@ class ProfileDataCardTest extends TestCase
             }
 
             $first_page_items_count = $data_count >= $per_page ? $per_page : $data_count;
-            
-            $this->assertIsIterable($component->lastRenderedView->data);
-            $this->assertCount($first_page_items_count, $component->lastRenderedView->data);
 
-            $component->call('gotoPage', $component->lastRenderedView->data->lastPage(), $section)
-                        ->assertSet('data_type', $section)
-                        ->assertViewHas('data');
-            
+            $data = $component->viewData('data');
+            $this->assertIsIterable($data);
+            $this->assertCount($first_page_items_count, $data);
+
+            $component->call('gotoPage', $data->lastPage(), $section)
+                ->assertSet('data_type', $section);
+
             $last_page_items_count = fmod($data_count, $per_page) > 0 ? fmod($data_count, $per_page) : $per_page;
-            $this->assertIsIterable($component->lastRenderedView->data);
-            $this->assertCount($last_page_items_count, $component->lastRenderedView->data);
+
+            $last_page_data = $component->viewData('data');
+            $this->assertIsIterable($last_page_data);
+            $this->assertCount($last_page_items_count, $last_page_data);
         } 
     }
 
@@ -126,12 +134,12 @@ class ProfileDataCardTest extends TestCase
             ->assertSessionHasNoErrors()
             ->assertStatus(200)
             ->assertViewIs('profiles.show');
-        
+
         foreach ($sections as $section) {
-            $component = Livewire::test(ProfileDataCard::class, ['profile' => $profile, 'editable' => $editable, 'data_type' => $section ])
-            ->assertHasNoErrors()
-            ->assertViewIs("livewire.profile-data-cards.{$section}")
-            ->call('nextPage');
+            $component = Livewire::test(ProfileDataCard::class, ['profile' => $profile, 'editable' => $editable, 'data_type' => $section])
+                ->assertHasNoErrors()
+                ->assertViewIs("livewire.profile-data-cards.{$section}")
+                ->call('nextPage', $section);
 
             $this->assertDatabaseHas('profile_data', ['type' => $section]);
 
@@ -139,14 +147,14 @@ class ProfileDataCardTest extends TestCase
                 method_exists($profile, $section),
                 'Profile does not have method '.$section
             );
-                
-            foreach ($component->lastRenderedView->data as $data) {
+            
+            foreach ($component->viewData('data') as $data) {
                 $this->assertContains($data->id, $profile->$section->pluck('id'));
-            };
-        
-            $this->assertArrayHasKey($section, $component->paginators);
-            $this->assertEquals(1, $component->paginators[$section]);
-            $this->assertEquals(2, $component->page);
+            }
+
+            $paginators = $component->get('paginators');
+            $this->assertArrayHasKey($section, $paginators);
+            $this->assertEquals(2, $paginators[$section]);
         }
     }  
 

--- a/tests/Feature/Livewire/ProfileStudentsTest.php
+++ b/tests/Feature/Livewire/ProfileStudentsTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Http\Livewire\ProfileStudents;
+use App\Profile;
+use App\Student;
+use App\StudentData;
+use Tests\Feature\Traits\HasJson;
+use Livewire\Livewire;
+use Tests\TestCase;
+use Tests\Feature\Traits\LoginWithRole;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ProfileStudentsTest extends TestCase
+{
+    use HasJson;
+    use LoginWithRole;
+    use RefreshDatabase;
+
+    /**
+     * Indicates whether the default seeder should run before each test.
+     *
+     * @var bool
+     */
+    protected $seed = true;
+
+    /** @test */
+    public function testStudentAppFilingStatusAndCountAfterUpdatingFilingStatus(): void
+    {
+        $profile = Profile::factory()
+                    ->hasData()
+                    ->create();
+
+        $student = Student::factory()
+                    ->submitted()
+                    ->has(StudentData::factory(), 'research_profile')
+                    ->hasAttached($profile, ['status' => 'follow up'], 'faculty')
+                    ->create();
+
+        $this->loginAsUser($profile->user);
+
+        $component = Livewire::test(ProfileStudents::class, [
+            'profile' => $profile,
+        ]);
+
+        $component->assertSeeHtmlInOrder([
+            'id="tab_pill_follow-up"',
+            '(1)',
+            'id="tab_pill_accepted"',
+            '(0)',
+            'id="tab_pill_maybe-later"',
+        ]);
+
+        $profile->students()->updateExistingPivot($student->id, [
+            'status' => 'accepted',
+        ]);
+
+        $component->dispatch('profileStudentStatusUpdated');
+
+        $component->assertSeeHtmlInOrder([
+            'id="tab_pill_follow-up"',
+            '(0)',
+            'id="tab_pill_accepted"',
+            '(1)',
+            'id="tab_pill_maybe-later"',
+        ]);
+    }
+
+    /** @test */
+    public function testFilingStatusApplicationCount(): void
+    {
+        $profile = Profile::factory()
+                    ->hasData()
+                    ->create();
+
+        $student = Student::factory()
+                    ->submitted()
+                    ->has(StudentData::factory(), 'research_profile')
+                    ->hasAttached($profile, ['status' => 'follow up'], 'faculty')
+                    ->create();
+
+        $this->loginAsUser($profile->user);
+
+        $component = Livewire::test(ProfileStudents::class, [
+            'profile' => $profile,
+        ]);
+
+        $component->assertSeeHtmlInOrder([
+            'id="tab_pill_"', '(0)',
+            'id="tab_pill_follow-up"', '(1)',
+            'id="tab_pill_accepted"', '(0)',
+            'id="tab_pill_maybe-later"', '(0)',
+            'id="tab_pill_not-interested"', '(0)',
+        ]);
+
+        $this->assertEquals(1, substr_count($component->html(), $student->full_name));
+
+        $profile->students()->updateExistingPivot($student->id, [
+            'status' => 'accepted',
+        ]);
+
+        $component->dispatch('profileStudentStatusUpdated');
+
+        $component->assertSeeHtmlInOrder([
+            'id="tab_pill_"', '(0)',
+            'id="tab_pill_follow-up"', '(0)',
+            'id="tab_pill_accepted"', '(1)',
+            'id="tab_pill_maybe-later"', '(0)',
+            'id="tab_pill_not-interested"', '(0)',
+        ]);
+
+        $this->assertEquals(1, substr_count($component->html(), $student->full_name));
+    }
+}

--- a/tests/Feature/Livewire/StudentFilerTest.php
+++ b/tests/Feature/Livewire/StudentFilerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Http\Livewire\StudentFiler;
+use App\Profile;
+use App\Student;
+use App\StudentData;
+use Tests\Feature\Traits\HasJson;
+use Livewire\Livewire;
+use Tests\TestCase;
+use Tests\Feature\Traits\LoginWithRole;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class StudentFilerTest extends TestCase
+{
+    use HasJson;
+    use LoginWithRole;
+    use RefreshDatabase;
+
+    /**
+     * Indicates whether the default seeder should run before each test.
+     *
+     * @var bool
+     */
+    protected $seed = true;
+
+    /** @test */
+    public function testFileStudentApplication(): void
+    {
+        $profile = Profile::factory()
+                    ->hasData()
+                    ->create();
+
+        //Create student app as follow up
+        $student = Student::factory()
+                    ->submitted()
+                    ->has(StudentData::factory(), 'research_profile')
+                    ->hasAttached($profile, ['status' => 'follow up'], 'faculty')
+                    ->create();
+
+        $this->loginAsUser($profile->user);
+
+        Livewire::test(StudentFiler::class, [
+            'profile' => $profile,
+            'student' => $student,
+            'status' => 'follow up',
+        ])
+            ->call('updateStatus', 'accepted', 'Accepted') // File as accepted
+            ->assertDispatched('profileStudentStatusUpdated');
+
+        $this->assertDatabaseHas('profile_student', [
+            'profile_id' => $profile->id,
+            'student_id' => $student->id,
+            'status' => 'accepted',
+        ]);
+    }
+}


### PR DESCRIPTION
This PR resolves the remaining functional and performance regressions in the Livewire 3 upgrade branch affecting the ProfileStudents, StudentFiler, ProfileDataCard, and TagsModal components. For reference, see the [upgrade guide](https://livewire.laravel.com/docs/3.x/upgrading).

### Changes include:

After installing Livewire 3, the `php artisan livewire:upgrade` command was used to address breaking changes progressively, through prompts. Some changes automatically applied across the Livewire components include:
- Update event dispatching from `emit()` to `dispatch()`
- Convert JavaScript event listeners and error handling to the Livewire 3 APIs
- `wire:model` directives update to `wire:model.live` since in Livewire 3, `wire:model` is "deferred" by default

Other syntax updates were done manually as follows:
- Replace `$listeners` with #[On] attributes
- Replace `getComputedProperty()` → `#[Computed] property()`

### Issues addressed:

**1.`RootTagMissingFromViewException` on `ProfileDataCard` component for public profile pages with empty sections:**
The `ProfileDataCard::render()` method returned `''` for empty, non-editable sections. Livewire 3 requires exactly one root element. Section partials now always render their root `<div>` wrapper with the emptiness conditional inside it; the empty-return branch is removed from the component's `render()` method.

**2. Duplicate refresh requests and toasts on student application status change:**
Filing a student should produce the following call stack: 
1. `StudentFiler->updateStatus()`
3. `ProfileStudent->profileStudentStatusUpdated`

Instead, the call was: 
1. `StudentFiler->updateStatus()`
2. `ProfileStudent->profileStudentStatusUpdated`
4.  `ProfileStudent->profileStudentStatusUpdated`

**Cause:**
The affected child component was declared using the v2 syntax :wire:key attribute:
 `<livewire:student-filer :wire:key="..." />`

For nested Livewire components, Livewire 3 uses :key to establish the component's identity:
`<livewire:student-filer :key="..." />`

There was also a second problem: the child's key did not change when the student's application status changed. When filing the student changed the status and moved the student-filer component to a different tab pane, Livewire 3 couldn't reconcile the original component instance with the new DOM position, so it created a new instance instead. When that new instance updated, it triggered `profileStudentStatusUpdated` again, causing the `ProfileStudent` handler to run a second time.

**Fix:**
Changed to Livewire 3 `:key` syntax and added the student's status to the key: `$student->slug . '_filer_' . $student->application->status`. This makes a status change a clean unmount/remount with no effects carried over. One request, one toast.

**3. Student application action icons disappeared after filing student application:** 
The Livewire hook 'message.processed' was removed and Livewire 3 now uses [morphing](https://livewire.laravel.com/docs/3.x/morphing) and the hook was updated to Livewire.hook('morphed', ({ el })).

**4. Profile Students page became slow/unresponsive after clearing `ProfileStudents` filters due to a DOM mutation storm caused by `dom.watch()` and an unscoped morphed hook (added in the previous fix):** 
 After clearing all the filters applied on the students applications, the request completed but the page became unresponsive or  significantly slow to re-render the DOM elements, even after the dev tools Network tab showed the request as completed. 

**Diagnosis:**
Used DevTools → Performance tab → record → cleared a student app filter → stopped recording after the UI finished rendering, the results showed a long ~34s task, where the majority of the subtasks were called by `Run microtasks`, with hundreds of repeated, near-identical function-call blocks, that showed the DOM node count went from ~5,725 to ~1,886,717, the event listeners also increased from 302 to 1,784. 

<img width="4772" height="3110" alt="image" src="https://github.com/user-attachments/assets/7a892bb2-48a7-4cc1-a5c6-39fbd43f66f4" />

The call tree shows that `MutationCallback` accounts for 54% of all samples, almost entirely Livewire's onMutate → initTree → walk/deferHandlingDirectives/directives — Livewire re-scanning and re-initializing subtrees every time the DOM changes.

**Cause:** 
Font Awesome 5's `dom.watch()` MutationObserver and Livewire 3's own mutation observer fed each other: every morph stripped nested `<svg>`s, font-awesome re-created them, and those insertions re-triggered Livewire's tree walks.

**Fix:**
Removed `dom.watch()`. Icons are converted once at `DOMContentLoaded` and the morph hook was scoped to the updated component (`Livewire.hook('morphed', ({ el }) => dom.i2svg({ node: el }))`) that re-converts only the component that just morphed, once per commit, instead of watching the whole document continuously. Re-profiled again: no measurable mutation storm, same ~276 ms Paint-dominated shape. The fix was also verified functionally by manually triggering a status change and a filter clear and confirmed icons survived both.

<img width="4802" height="1414" alt="image" src="https://github.com/user-attachments/assets/3ba9ffd2-2dc6-4163-baca-fccec75a95d1" />

**5. Test suite migration and new coverage**
- Data card tests no longer use `lastRendered()` as public methods (internal-only in v3): assertions use `viewData()` (re-fetched after each `call()`) and `call('nextPage', $section)` for the per-section named paginators — also fixing a latent v2 bug where tests advanced the default `page` paginator.
- `assertSeeHtmlInOrder` fragments rebuilt: v3 injects `wire:snapshot`/`wire:effects`/`wire:id` into root elements and wraps conditionals in `<!--[if BLOCK]-->` markers, affecting the assertion result. The assertion arguments are checked individually now.
- Added coverage for `StudentFiler::updateStatus` and `ProfileStudents` o verify the basic student application filing interaction, including that the record status is updated and displayed under the correct category and that each category's count is accurate.

**6. Updated Tags event listener for student application form:**
Fixed the listener to use `Livewire.dispatch(event, { tag_type: ... })`, switched the direct binding to a delegated `$(document).on('change', selector, ...)` so it survives Livewire morphs of that region, and collapsed the if/else into a single dispatch call.

### Components tested manually:
1. Bookmarkbutton
2. DelegationsTable
3. StudentFeedback

### Steps to test:
1. `composer install`
4. `docker exec php.profiles php artisan optimize:clear`