### PR TITLE
Restrict Student Application Review Notifications to Profiles Accepting Students

### DIFF
--- a/app/Console/Commands/NotifyProfilesAboutStudents.php
+++ b/app/Console/Commands/NotifyProfilesAboutStudents.php
@@ -47,9 +47,10 @@ class NotifyProfilesAboutStudents extends Command
         $year = (int)$this->argument('year');
 
         $semester = ($season && $year) ? Semester::formatName($season, $year) : Semester::current();
-        $faculty_list = Profile::StudentsPendingReviewWithSemester($semester)
-                                ->EagerStudentsPendingReviewWithSemester($semester)
-                                ->with('user:id,email,display_name')->get();
+        $faculty_list = Profile::AcceptingUndergradStudents()
+                                    ->EagerStudentsPendingReviewWithSemester($semester)
+                                    ->with('user:id,email,display_name')
+                                    ->get();
 
         foreach ($faculty_list as $faculty) { 
             $count = $faculty->students->count();


### PR DESCRIPTION
The profiles collection for student application notifications is now scoped to include only profiles that are not marked as "Not accepting students." This prevents profiles whose status has changed to "Not accepting students," but are still included in existing student applications that have been updated to include future semesters, from receiving email notifications.